### PR TITLE
Fix stalemate adjudication for shogi

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -611,9 +611,9 @@ class Game:
                 self.status = MATE
                 self.result = "1-0" if self.board.color == BLACK else "0-1"
             else:
-                # being in stalemate loses in xiangqi
+                # being in stalemate loses in xiangqi and shogi variants
                 self.status = STALEMATE
-                if self.variant == "xiangqi":
+                if self.variant.endswith(("xiangqi", "shogi")):
                     self.result = "0-1" if self.board.color == WHITE else "1-0"
                 else:
                     print("1/2 by stalemate")


### PR DESCRIPTION
Stalemate is scored as a win for the stalemating player in shogi variants. See https://pychess-variants.herokuapp.com/F4Krs90b for an example of the bug.

Note: This code implicitly also already covers minixiangqi in case it will be added.

Ultimately, I think it would be better to let pyffish decide on the game result, but for now I chose a minimal fix.