### PR TITLE
Remove leading zero when rounding up clock time

### DIFF
--- a/client/clock.ts
+++ b/client/clock.ts
@@ -112,7 +112,7 @@ export class Clock {
             secs = String(Math.floor(seconds));
         }
         mins = (minutes < 10 ? "0" : "") + String(minutes);
-        secs = (seconds < 10 ? "0" : "") + secs;
+        secs = (seconds < 10 && secs.length < 4 ? "0" : "") + secs;
         return {
             minutes: mins,
             seconds: secs,


### PR DESCRIPTION
Behavior observed at https://www.twitch.tv/videos/541288181?t=0h20m35s

When rounding up to 0:10.0 (e.g., with 9999 milliseconds) 0:010.0 was displayed instead.