### PR TITLE
Fix board/piece icon overflow in the settings panel

### DIFF
--- a/static/preview.css
+++ b/static/preview.css
@@ -1,6 +1,6 @@
 /* Board settings */
 .settings-pieces, .settings-boards {
-  display: flex;
+  display: block;
   border: none;
   margin: 12px;
 }

--- a/static/site.css
+++ b/static/site.css
@@ -1076,7 +1076,8 @@ cg-resize {
 /* range input slider */
 .slider {
   -webkit-appearance: none;
-  width: 100%;
+  width: 98%;
+  margin: 2px auto;
   height: 25px;
   border-radius: 5px;
   background: LightGray;
@@ -1211,7 +1212,7 @@ minigame:hover {
   -webkit-animation: spin 0.6s linear infinite;
   animation: spin 0.6s linear infinite;
 }
- 
+
 @-webkit-keyframes spin {
   0% {
     -webkit-transform: rotate(0deg);


### PR DESCRIPTION
At least until we have a better solution or a new settings panel, this could be a (temporary) fix for games which have more than 5 sets of pieces/boards. Also, the zoom slider is centered in the box with a tiny "margin" instead of displaying it from edge to edge.

 ![screenshot](https://i.imgur.com/NtOt1ZA.png)