### PR TITLE
Fix zoom slider's blurry scale

### DIFF
--- a/client/settings.ts
+++ b/client/settings.ts
@@ -323,7 +323,7 @@ export function settingsView (ctrl) {
         // h('label.zoom', { attrs: {for: "zoom"} }, "Board size"),
         h('input#zoom', {
             class: {"slider": true },
-            attrs: { name: 'zoom', width: '280px', type: 'range', value: Number(zoom), min: 50, max: 150, step: (ctrl.variant.endsWith('shogi')) ? 1 : 1.5625 },
+            attrs: { name: 'zoom', title: '[-] Zoom [+]', width: '280px', type: 'range', value: Number(zoom), min: 50, max: 150, step: (ctrl.variant.endsWith('shogi')) ? 1 : 1.5625 },
             on: { input: (e) => { setZoom(ctrl, parseFloat((e.target as HTMLInputElement).value)); } }
             }
         ),

--- a/client/settings.ts
+++ b/client/settings.ts
@@ -144,7 +144,7 @@ export function toggleOrientation (ctrl) {
         const color = ctrl.chessground.state.orientation === "white" ? "white" : "black";
         setPieces(ctrl, color, true);
     };
-    
+
     console.log("FLIP");
     if (ctrl.hasPockets) {
         const tmp_pocket = ctrl.pockets[0];
@@ -181,7 +181,7 @@ export function gearButton (ctrl) {
         class: {"selected": ctrl.settings} },
         [h('i', {
             props: {title: 'Settings'},
-            class: {"icon": true, "icon-cog": true} 
+            class: {"icon": true, "icon-cog": true}
             }
         )])
 }
@@ -323,7 +323,7 @@ export function settingsView (ctrl) {
         // h('label.zoom', { attrs: {for: "zoom"} }, "Board size"),
         h('input#zoom', {
             class: {"slider": true },
-            attrs: { name: 'zoom', width: '280px', type: 'range', value: Number(zoom), min: 60, max: 160 },
+            attrs: { name: 'zoom', width: '280px', type: 'range', value: Number(zoom), min: 50, max: 150, step: (ctrl.variant.endsWith('shogi')) ? 1 : 1.5625 },
             on: { input: (e) => { setZoom(ctrl, parseFloat((e.target as HTMLInputElement).value)); } }
             }
         ),

--- a/static/site.css
+++ b/static/site.css
@@ -573,6 +573,24 @@ table#seeks {
   border: 1px solid var(--bg-color2);
 }
 
+/*Adjust lobby game table/headers*/
+
+#seeks > thead > tr > th:nth-child(6) {
+    padding-right:7.4em;
+}
+
+#seeks > thead > tr > th:nth-child(7) {
+    padding-right:2em;
+}
+
+#seeks > tbody > tr > td:nth-child(3) {
+    padding-right:1.4em;
+}
+
+i-side.icon.icon-adjust {
+    padding-right:1em;
+}
+
 #seeks tbody tr:hover {
   width:100%;
   background-color: var(--rusty);

--- a/static/site.css
+++ b/static/site.css
@@ -1100,8 +1100,8 @@ cg-resize {
   background: LightGray;
   outline: none;
   opacity: 0.7;
-  -webkit-transition: .2s;
-  transition: opacity .2s;
+/*  -webkit-transition: .2s;*/
+  /*transition: opacity .2s;*/
 }
 
 .slider:hover {


### PR DESCRIPTION
Except for shogi, like I mentioned it on Discord. This blurry scaling problem exists mostly in Chrome/Chromium (and I guess in other Chromium-based browsers). It seems to me that Firefox scales SVG better (not as blurry).

Side note: in Firefox we can click on the slider and use the mouse wheel to zoom in/out (smoother than dragging the slider thumb). This doesn't work in Chrome/Chromium, but I guess it's a browser feature.