### PR TITLE
Sugestion: Update Project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Your contribution will be greatly appreciated and help me continue to develop th
 ```
 pip3 install -r requirements.txt --user
 yarn install
-gulp prod
+yarn gulp prod
 ```
 
 ### Start server


### PR DESCRIPTION
by using `yarn gulp prod` instead of `gulp prod` you make sure that people always run the dependency version specified by the project instead of running with their global gulp's version.
It also doesn't work if you don't have gulp installed globally on your machine.