### PR TITLE
Analysis board navigation

### DIFF
--- a/client/analysisCtrl.ts
+++ b/client/analysisCtrl.ts
@@ -970,8 +970,14 @@ export default class AnalysisController {
                     selectMove(this, this.ply);
                     return;
                 }
-                this.plyVari = this.ply;
-                this.steps[this.plyVari]['vari'] = [];
+                if (this.steps[this.plyVari]['vari'] === undefined || msg.ply === this.steps[this.plyVari]['vari'].length) {
+                    // continuing the variation
+                    this.plyVari = this.ffishBoard.gamePly();
+                    this.steps[this.plyVari]['vari'] = [];
+                } else {
+                    // variation in the variation: drop old moves
+                    this.steps[this.plyVari]['vari'] = this.steps[this.plyVari]['vari'].slice(0, this.ffishBoard.gamePly() - this.plyVari);    
+                }
             }
             this.steps[this.plyVari]['vari'].push(step);
 

--- a/client/analysisCtrl.ts
+++ b/client/analysisCtrl.ts
@@ -955,9 +955,9 @@ export default class AnalysisController {
             };
 
         // New main line move
-        if (msg.ply === this.steps.length && this.plyVari === 0) {
+        if (this.ffishBoard.gamePly() === this.steps.length && this.plyVari === 0) {
             this.steps.push(step);
-            this.ply = msg.ply
+            this.ply = this.ffishBoard.gamePly()
             updateMovelist(this);
 
             this.checkStatus(msg);

--- a/client/movelist.ts
+++ b/client/movelist.ts
@@ -13,7 +13,7 @@ import { boardSettings } from './boardSettings';
 import AnalysisController from "./analysisCtrl";
 import RoundController from "./roundCtrl";
 
-export function selectMove (ctrl: AnalysisController | RoundController, ply: number, plyVari: number = 0) {
+export function selectMove (ctrl: AnalysisController | RoundController, ply: number, plyVari = 0): void {
     ctrl.goPly(ply, plyVari);
     if (plyVari == 0) {
         activatePly(ctrl);

--- a/client/movelist.ts
+++ b/client/movelist.ts
@@ -10,8 +10,10 @@ import h from 'snabbdom/h';
 import { VNode } from 'snabbdom/vnode';
 
 import { boardSettings } from './boardSettings';
+import AnalysisController from "./analysisCtrl";
+import RoundController from "./roundCtrl";
 
-export function selectMove (ctrl, ply, plyVari = 0) {
+export function selectMove (ctrl: AnalysisController | RoundController, ply: number, plyVari: number = 0) {
     ctrl.goPly(ply, plyVari);
     if (plyVari == 0) {
         activatePly(ctrl);

--- a/client/movelist.ts
+++ b/client/movelist.ts
@@ -11,10 +11,15 @@ import { VNode } from 'snabbdom/vnode';
 
 import { boardSettings } from './boardSettings';
 
-export function selectMove (ctrl, ply) {
-    ctrl.goPly(ply);
-    activatePly(ctrl);
-    scrollToPly(ctrl);
+export function selectMove (ctrl, ply, plyVari = 0) {
+    ctrl.goPly(ply, plyVari);
+    if (plyVari == 0) {
+        activatePly(ctrl);
+        scrollToPly(ctrl);
+    } else {
+        activatePlyVari(ply + plyVari);
+    }
+
 }
 
 function activatePly (ctrl) {
@@ -40,11 +45,6 @@ function scrollToPly (ctrl) {
         movelistEl.scrollTop = st;
 }
 
-function selectVariMove (ctrl, ply, plyVari) {
-    ctrl.goPly(ply, plyVari);
-    activatePlyVari(ply + plyVari);
-}
-
 export function activatePlyVari (ply) {
     console.log('activatePlyVari()', ply);
     const active = document.querySelector('vari-move.active');
@@ -59,14 +59,20 @@ export function createMovelistButtons (ctrl) {
     ctrl.moveControls = patch(container, h('div#btn-controls-top.btn-controls', [
         h('button#flip', { on: { click: () => boardSettings.toggleOrientation() } }, [ h('i.icon.icon-refresh', { props: { title: 'Flip board' } } ) ]),
         h('button', { on: { click: () => selectMove(ctrl, 0) } }, [ h('i.icon.icon-fast-backward') ]),
-        h('button', { on: { click: () => selectMove(ctrl, Math.max(ctrl.ply - 1, 0)) } }, [ h('i.icon.icon-step-backward') ]),
-        h('button', { on: { click: () => selectMove(ctrl, Math.min(ctrl.ply + 1, ctrl.steps.length - 1)) } }, [ h('i.icon.icon-step-forward') ]),
+        h('button', { on: { click: () => { 
+            // this line is necessary, but I don't understand why
+            ctrl.ply = Math.min(ctrl.ply, ctrl.plyVari > 0 ? ctrl.steps[ctrl.plyVari]['vari'].length - 1 : Number.MAX_VALUE);
+            selectMove(ctrl, 
+                (ctrl.ply == 0 && ctrl.plyVari > 0) ? ctrl.plyVari : Math.max(ctrl.ply - 1, 0), 
+                (ctrl.ply == 0 && ctrl.plyVari > 0) ? 0 : ctrl.plyVari) 
+            } 
+        } }, [ h('i.icon.icon-step-backward') ]),
+        h('button', { on: { click: () => selectMove(ctrl, Math.min(ctrl.ply + 1, (ctrl.plyVari > 0 ? ctrl.steps[ctrl.plyVari]['vari'].length : ctrl.steps.length) - 1), ctrl.plyVari) } }, [ h('i.icon.icon-step-forward') ]),
         h('button', { on: { click: () => selectMove(ctrl, ctrl.steps.length - 1) } }, [ h('i.icon.icon-fast-forward') ]),
     ]));
 }
 
 export function updateMovelist (ctrl, full = true, activate = true) {
-
     const plyFrom = (full) ? 1 : ctrl.steps.length -1
     const plyTo = ctrl.steps.length;
 
@@ -101,7 +107,7 @@ export function updateMovelist (ctrl, full = true, activate = true) {
                     const moveCounter = (currPly % 2 !== 0) ? (currPly + 1) / 2 + '. ' : (idx === 0) ? Math.floor((currPly + 1) / 2) + '...' : ' ';
                     return h('vari-move', {
                         attrs: { ply: currPly },
-                        on: { click: () => selectVariMove(ctrl, idx, ctrl.plyVari) },
+                        on: { click: () => selectMove(ctrl, idx, ctrl.plyVari) },
                         }, [ h('san', moveCounter + x['san']) ]
                     );
                 })


### PR DESCRIPTION
This fixes the issue where variations in the analysis board are always registered as variations of the first move. Also, it makes it possible to append new moves at the end of the move list, and to navigate the move list, even inside variations, with the step buttons. Only one variation at a time is supported.