### PR TITLE
Fix project dev setup for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ yarn install
 yarn dev
 ```
 
+For MacOS, replace the last command with:
+```
+yarn dev-mac
+```
+
 ### Start server
 ```
 python3 server/server.py

--- a/md2html-mac.sh
+++ b/md2html-mac.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Learn docs
+cd static/docs
+
+export PATH="../../node_modules/.bin/:$PATH"
+
+for f in *.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).html" --flavor github
+done
+
+for f in es/*.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).es.html" --flavor github
+done
+
+for f in hu/*.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).hu.html" --flavor github
+done
+
+for f in it/*.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).it.html" --flavor github
+done
+
+for f in pt/*.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).pt.html" --flavor github
+done
+
+for f in fr/*.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).fr.html" --flavor github
+done
+
+showdown makehtml -i "zh/intro.md" -o "intro.zh.html" --flavor github
+
+
+SRC='https://github.com/gbtami/pychess-variants/blob/master'; 
+#DST='https://www.pychess.org';
+DST='https://cdn.jsdelivr.net/gh/gbtami/pychess-variants@1.6.2';
+find . -type f -name "*.html" -exec sed -i '' 's,'"$SRC"','"$DST"',g' {} \;
+
+mkdir -p ../../templates/docs
+mv *.html ../../templates/docs
+
+# News
+cd ../news
+
+for f in *.md; do
+showdown makehtml -i "$f" -o "$(basename -- "$f" .md).html" --flavor github
+done
+
+find . -type f -name "*.html" -exec sed -i '' 's,'"$SRC"','"$DST"',' {} \;
+
+mkdir -p ../../templates/news
+mv *.html ../../templates/news

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "scripts": {
     "dev": "cp node_modules/ffish-es6/ffish.* static/ && gulp dev && ./md2html.sh",
+    "dev-mac": "cp node_modules/ffish-es6/ffish.* static/ && gulp dev && ./md2html-mac.sh",
     "heroku-postbuild": "cp node_modules/ffish-es6/ffish.* static/ && gulp prod && ./md2html.sh",
     "test": "mocha -r ts-node/register -r jsdom-global/register 'tests/**/*.test.ts'"
   }


### PR DESCRIPTION
@gbtami I only tested this in Mac (and it's working). I tried to keep Linux's implementation as it was and defaulted to the Linux setup for any O.S. other than Mac. But as I refactored the script a bit, I'd like you to test it on Linux before accepting this PR, in case I broke something 😬 

I rewrote `md2html.sh` a bit, abstracting some functions to avoid duplication. By detecting the OS first, then we load `mac.sh` or `linux.sh` with specific commands for each. It's not the best implementation because many things are the same, but this way at least they can be versioned apart if any new difference appears, and also `md2html.sh` is simpler and hopefully easier to maintain 🤞 


--[ commit message: ]-----

MacOS comes usually with old bash and sh versions, so some commands are
not exactly as in Linux.

Namely for our case, there's no `-t` option for `mv`, and the `-i` flag
of `find` requires always a value after it.

I refactored a bit the script md2html.sh to avoid some duplication, but
tried to keep the implementation that currently works for linux.