### PR TITLE
Zen Mode

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -25,6 +25,7 @@ import { volumeSettings, soundThemeSettings } from './sound';
 import { getCookie } from './document';
 import { backgroundSettings } from './background';
 import { renderTimeago } from './datetime';
+import { zenButtonView, zenModeSettings } from './zen';
 
 // redirect to correct URL except Heroku preview apps
 if (window.location.href.includes('heroku') && !window.location.href.includes('-pr-')) {
@@ -122,11 +123,14 @@ function start() {
         if (!settingsPanel.contains(event.target as Node))
             settings.style.display = 'none';
     });
+
+    patch(document.getElementById('zen-button') as HTMLElement, zenButtonView()).elm as HTMLElement;
 }
 
 window.addEventListener('resize', () => document.body.dispatchEvent(new Event('chessground.resize')));
 
 backgroundSettings.update();
+zenModeSettings.update();
 
 const el = document.getElementById('pychess-variants');
 if (el instanceof Element) {

--- a/client/settingsView.ts
+++ b/client/settingsView.ts
@@ -14,6 +14,7 @@ import { selectVariant } from './chess';
 import { getDocumentData } from './document';
 import { _, translatedLanguage, languageSettings } from './i18n';
 import { volumeSettings, soundThemeSettings } from './sound';
+import { zenModeSettings } from './zen';
 
 export function settingsView() {
     const anon = getDocumentData('anon');
@@ -27,6 +28,7 @@ export function settingsView() {
                 soundSettingsView(),
                 backgroundSettingsView(),
                 boardSettingsView(),
+                zenModeSettingsView(),
             ]),
         ]),
     ]);
@@ -72,6 +74,7 @@ function settingsMenu() {
         h('button#btn-sound', { on: { click: showSubsettings } }, _('Sound')),
         h('button#btn-background', { on: { click: showSubsettings } }, _('Background')),
         h('button#btn-board', { on: { click: showSubsettings } }, _('Board Settings')),
+        h('button#btn-zen', { on: { click: showSubsettings } }, _('Zen Mode')),
     ]);
 }
 
@@ -116,6 +119,13 @@ function backgroundSettingsView() {
     return h('div#settings-background', [
         backButton(_("Background")),
         backgroundSettings.view(),
+    ]);
+}
+
+function zenModeSettingsView() {
+    return h('div#settings-zen', [
+        backButton(_("Zen Mode")),
+        zenModeSettings.view(),
     ]);
 }
 

--- a/client/zen.ts
+++ b/client/zen.ts
@@ -1,0 +1,42 @@
+import { h } from 'snabbdom/h';
+import { VNode } from 'snabbdom/vnode';
+
+import { _ } from './i18n';
+import { StringSettings } from './settings';
+import { radioList } from './view';
+
+const zenModeOptions = {
+    off: _("Off"),
+    on: _("On"),
+};
+
+class ZenModeSettings extends StringSettings {
+
+    constructor() {
+        super('zen', 'off');
+    }
+
+    update(): void {
+        document.documentElement.setAttribute('data-zen', this.value);
+    }
+
+    view(): VNode {
+        return h('div#zen-selector', radioList(this, 'zen', zenModeOptions, (_, key) => this.value = key));
+    }
+
+}
+
+export const zenModeSettings = new ZenModeSettings();
+
+function deactivateZenMode() {
+    zenModeSettings.value = 'off';
+    zenModeSettings.update();
+}
+
+export function zenButtonView() {
+    return h('button#zen-button', { on: { click: deactivateZenMode } }, [
+        h('div.icon.icon-check'),
+        _('ZEN MODE'),
+    ]);
+}
+

--- a/static/round.css
+++ b/static/round.css
@@ -106,3 +106,14 @@
     -webkit-animation:bar-glider-anim 3s linear infinite;
     animation:bar-glider-anim 3s linear infinite
 }
+
+@media (min-width: 800px) {
+    [data-zen="on"] .round-app {
+        grid-template-rows: min-content auto min-content auto 0 auto auto auto 0 auto min-content auto min-content
+    }
+}
+@media (max-width: 799px) and (orientation: portrait) {
+    [data-zen="on"] .round-app {
+        grid-template-rows: auto auto 36px auto auto min-content 36px auto auto auto auto auto auto auto;
+    }
+}

--- a/static/site.css
+++ b/static/site.css
@@ -1826,3 +1826,21 @@ div#ctable-container {
 .tour-spotlight .more {
     font-size: 0.85em;
 }
+button#zen-button {
+    display: none;
+    border: none;
+    color: var(--font-color);
+    cursor: pointer;
+    padding: 20px;
+    margin: 5px;
+}
+[data-zen="on"] round-player0,
+[data-zen="on"] round-player1,
+[data-zen="on"] .sidebar-first,
+[data-zen="on"] .site-title-nav,
+[data-zen="on"] #spectators {
+    display: none;
+}
+[data-zen="on"] button#zen-button {
+    display: flex;
+}

--- a/templates/template.html
+++ b/templates/template.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block header %}
     <header>
+        <button id="zen-button">
+        </button>
         <div class="site-title-nav">
             <div class="hamburger hamburger--vortex">
                 <div class="hamburger-box">


### PR DESCRIPTION
Fixes #555 
--

Adds a setting for Zen Mode (On/Off) defaulted to Off.

Inspired by lichess, Zen Mode hides:
 * Player names and ratings
 * Left sidebar (chat, game info)
 * Main top menu
 * Spectators

It also adds a top left button 'ZEN MODE' to go back to normal.