### PR TITLE
Hide crosstable and move-list in zen mode

### DIFF
--- a/static/round.css
+++ b/static/round.css
@@ -146,6 +146,8 @@ a#zen-button:hover {
 [data-zen="on"] round-player1,
 [data-zen="on"] .sidebar-first,
 [data-zen="on"] .site-title-nav,
+[data-zen="on"] .crosstable,
+[data-zen="on"] move,
 [data-zen="on"] #spectators {
     display: none;
 }


### PR DESCRIPTION
Note that since I didn't fix my login problem in local I haven't tested the crosstable (but it should work).

--[commit message]------------------------
They are distractions as well, so we should hide them too, same as
lichess does.

We hide each "move" instead of the whole #movelist to hide all the moves
but not the container that includes, for example the result of the game.
We don't hide the rematch/analysis buttons either. Again, same as lichess.