### PR TITLE
Support basic Ctrl autoqueen disable

### DIFF
--- a/client/promotion.ts
+++ b/client/promotion.ts
@@ -26,7 +26,7 @@ export class Promotion {
         this.choices = {};
     }
 
-    start(movingRole: Role, orig: Key, dest: Key) {
+    start(movingRole: Role, orig: Key, dest: Key, disableAutoqueen: boolean = false) {
         const ground = this.ctrl.getGround();
         // in 960 castling case (king takes rook) dest piece may be undefined
         if (ground.state.pieces[dest] === undefined) return false;
@@ -36,7 +36,7 @@ export class Promotion {
             const orientation = ground.state.orientation;
             const pchoices = this.promotionChoices(movingRole, orig, dest);
 
-            if (this.ctrl instanceof RoundController && this.ctrl.autoqueen && this.ctrl.variant.autoQueenable && 'q-piece' in pchoices)
+            if (this.ctrl instanceof RoundController && this.ctrl.autoqueen && !disableAutoqueen && this.ctrl.variant.autoQueenable && 'q-piece' in pchoices)
                 this.choices = { 'q-piece': 'q' };
             else
                 this.choices = pchoices;

--- a/client/roundCtrl.ts
+++ b/client/roundCtrl.ts
@@ -1040,9 +1040,9 @@ export default class RoundController {
 
         //  gating elephant/hawk
         if (this.variant.gate) {
-            if (!this.promotion.start(moved.role, orig, dest) && !this.gating.start(this.fullfen, orig, dest)) this.sendMove(orig, dest, '');
+            if (!this.promotion.start(moved.role, orig, dest, meta.ctrlKey) && !this.gating.start(this.fullfen, orig, dest)) this.sendMove(orig, dest, '');
         } else {
-            if (!this.promotion.start(moved.role, orig, dest)) this.sendMove(orig, dest, '');
+            if (!this.promotion.start(moved.role, orig, dest, meta.ctrlKey)) this.sendMove(orig, dest, '');
             this.preaction = false;
         }
     }


### PR DESCRIPTION
https://github.com/gbtami/pychess-variants/issues/478
So far dealing only with discarding autoqueen when making a regular move, not a premove.
What do you think would be the more natural behaviour, to ask to choose a piece when making the premove (like on lichess), or when the premove actually fires (like here without autoqueen enabled)?