### PR TITLE
Update sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 # These are supported funding model platforms
 
-patreon: pychess 
-custom: ['https://paypal.me/gbtami']
+custom: ['https://www.pychess.org/patron]


### PR DESCRIPTION
Rather than mentioning both patreon and paypal link can just mention pychess.org/patron, just as like lichess