### PR TITLE
Make built in custom starting position names translatable

### DIFF
--- a/client/i18n.ts
+++ b/client/i18n.ts
@@ -76,6 +76,18 @@ export const translatedVariantDisplayNames = [
     _("orda"), _("synochess"), _("shinobi"), _("empire"), _("orda mirror"), _("chak"),
 ];
 
+export const translatedCustomStartPositions = [
+    _('PawnsPushed'), _('PawnsPassed'), _('UpsideDown'), _('Theban'), _('No castle'),
+
+    _('Lance HC'), _('Bishop HC'), _('Rook HC'), _('Rook+Lance HC'), _('2-Piece HC'), _('4-Piece HC'), _('6-Piece HC'), _('8-Piece HC'), _('9-Piece HC'), _('10-Piece HC'),
+
+    _('Gorogoro Plus N+L'), _('Original (No N+L)'),
+
+    _('Left Quail HC'), _('Falcon HC'), _('Falcon + Left Quail HC'), _('Falcon + Both Quails HC'),
+
+    _('Bird'), _('Carrera'), _('Gothic'), _('Embassy'), _('Conservative'),
+];
+
 class LanguageSettings extends StringSettings {
     constructor() {
         super('lang', 'en');

--- a/client/lobby.ts
+++ b/client/lobby.ts
@@ -723,7 +723,7 @@ export class LobbyController {
     }
     private mode(seek: Seek) {
         if (seek.alternateStart)
-            return seek.alternateStart;
+            return _(seek.alternateStart);
         else if (seek.fen)
             return _("Custom");
         else if (seek.rated)


### PR DESCRIPTION
#790 
I know those names appear in 2 contexts namely creating a seek and displaying already existing seeks, but the former already had call of _() https://github.com/gbtami/pychess-variants/blob/master/client/lobby.ts#L592