### PR TITLE
Stop aborting casual games due to not making the first move in time

### DIFF
--- a/client/roundCtrl.ts
+++ b/client/roundCtrl.ts
@@ -981,7 +981,9 @@ export class RoundController extends GameController {
     }
 
     private renderExpiration = () => {
-        if (this.spectator) return;
+        // We return sooner in case the client belongs to a spectator or the 
+        // game is casual as casual games can't expire.
+        if (this.spectator || this.rated === "0") return;
         let position = (this.turnColor === this.mycolor) ? "bottom": "top";
         if (this.flipped()) position = (position === "top") ? "bottom" : "top";
         let expi = (position === 'top') ? 0 : 1;

--- a/server/clock.py
+++ b/server/clock.py
@@ -33,9 +33,9 @@ class Clock:
             # give some time to make first move
             if self.ply < 2:
                 if self.game.rated == CASUAL:
-                    # Casual games are not times for the first moves of either
+                    # Casual games are not timed for the first moves of either
                     # player. We stop the clock to prevent unnecessary clock
-                    # updates and giving players unlimited time.
+                    # updates and to give players unlimited time.
                     self.running = False
                     return
                 # Rated games have their first move time set
@@ -59,12 +59,7 @@ class Clock:
                     # until the other side gets the win claim,
                     # and a disconnection gets 120 seconds.
                     if self.ply >= 2:
-                        await asyncio.sleep(20 + self.game.byoyomi_period * self.game.inc) 
-                    elif self.game.rated == CASUAL:
-                        # Ignore "time_for_first_move" in a casual game
-                        # and continue early
-                        await asyncio.sleep(1)
-                        continue
+                        await asyncio.sleep(20 + self.game.byoyomi_period * self.game.inc)  
 
                     # If FLAG was not received we have to act
                     if self.game.status < ABORTED and self.secs <= 0 and self.running:


### PR DESCRIPTION
See #976 
These changes prevent a casual game from aborting due to not playing the first move in time by stopping the countdown. They also stop client from rendering expiration times in casual games.