### PR TITLE
Add flipped Chennis piece sets

### DIFF
--- a/client/variants.ts
+++ b/client/variants.ts
@@ -60,7 +60,7 @@ export const PIECE_FAMILIES: Record<string, PieceFamily> = {
     empire: { pieceCSS: ["empire0", "empire1", "disguised"] },
     ordamirror: { pieceCSS: ["ordamirror0", "ordamirror1", "disguised"] },
     chak: { pieceCSS: ["chak0", "disguised"] },
-    chennis: { pieceCSS: ["chennis0", "chennis1", "chennis2", "disguised"] },
+    chennis: { pieceCSS: ["chennis0", "chennis1", "chennis2", "chennis3", "chennis4", "disguised"] },
     spartan: { pieceCSS: ["spartan0", "disguised"] },
     mansindam: { pieceCSS: ["mansindam2", "mansindam1", "mansindam3", "disguised"] },
 };

--- a/static/images/pieces/chennis/bBS_r.svg
+++ b/static/images/pieces/chennis/bBS_r.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg2118"
+   sodipodi:docname="bBS.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata2124">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2122" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview2120"
+     showgrid="false"
+     inkscape:zoom="3.959798"
+     inkscape:cx="-125.19168"
+     inkscape:cy="10.493778"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2118"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g2116">
+    <g
+       fill="#000"
+       stroke-linecap="butt"
+       id="g2112">
+      <path
+         d="m 35.999995,8.3163007 c -3.39,0.97 -10.11,-0.43 -13.5,2.0000003 -3.39,-2.4300003 -10.11,-1.0300003 -13.4999997,-2.0000003 0,0 -1.65,-0.54 -3,-2 0.68,-0.97 1.65,-0.99 3,-0.5 3.3899997,0.97 10.1099997,-0.46 13.4999997,1 3.39,-1.46 10.11,-0.03 13.5,-1 1.354,-0.49 2.323,-0.47 3,0.5 -1.354,1.94 -3,2 -3,2 z"
+         id="path2106" />
+      <path
+         d="m 29.999995,12.316301 c -2.5,-2.5000003 -12.5,-2.5000003 -15,0 -0.5,1.5 0,2 0,2 0,2.5 2.5,4 2.5,4 -5.5,1.5 -6,11.5 5,15.5 11,-4 10.5,-14 5,-15.5 0,0 2.5,-1.5 2.5,-4 0,0 0.5,-0.5 0,-2 z"
+         id="path2108" />
+      <path
+         d="m 19.999995,36.316301 a -2.5,-2.5 0 1 1 5,0 -2.5,-2.5 0 1 1 -5,0 z"
+         id="path2110" />
+    </g>
+    <path
+       d="m 27.499995,18.316301 h -10 m 12.5,-4 h -15"
+       stroke="#ececec"
+       stroke-linejoin="miter"
+       id="path2114"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <path
+     id="path2176-6"
+     style="fill:#3e588a;fill-opacity:1;stroke:none;stroke-width:0.651777;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 22.499995,32.377741 c 1.15332,-2.766482 4.426758,-5.166165 5.510385,-6.058489 -2.177796,0.138362 -3.895198,0.555678 -4.64325,0.549764 0.352798,-4.656068 4.370272,-3.664518 4.371512,-6.685584 -1.524366,0 -3.366686,0.0081 -5.238647,0.01616 -1.87196,-0.0081 -3.714279,-0.01616 -5.238647,-0.01616 0.0013,3.021066 4.018713,2.029516 4.371511,6.685584 -0.748053,0.0059 -2.465453,-0.411402 -4.643249,-0.549764 1.083626,0.892324 4.357065,3.292007 5.510385,6.058489 z"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/static/images/pieces/chennis/bCF_r.svg
+++ b/static/images/pieces/chennis/bCF_r.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg6582"
+   sodipodi:docname="bCF.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata6588">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6586">
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4403"
+       x="-1.08e-05"
+       width="1.0000216"
+       y="-1.08e-05"
+       height="1.0000216">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.475e-05"
+         id="feGaussianBlur4405" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview6584"
+     showgrid="false"
+     inkscape:zoom="9.6444444"
+     inkscape:cx="51.056284"
+     inkscape:cy="46.496287"
+     inkscape:window-x="-12"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6582" />
+  <g
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g10992"
+     transform="matrix(0.6453104,0.37257013,-0.37257013,0.6453104,17.519228,-4.6935226)">
+    <g
+       stroke="none"
+       id="g10982">
+      <circle
+         cx="-46.192211"
+         cy="-43.585686"
+         r="2.75"
+         id="circle10972"
+         style="fill:#3e588a;fill-opacity:1"
+         transform="scale(-1)" />
+      <circle
+         cx="22.5"
+         cy="8"
+         r="2.75"
+         id="circle10976"
+         style="fill:#3e588a;fill-opacity:1;filter:url(#filter4403)"
+         transform="rotate(180,26.096106,27.792842)" />
+      <circle
+         cx="-13.192212"
+         cy="-43.585686"
+         r="2.75"
+         id="circle10980"
+         style="fill:#3e588a;fill-opacity:1"
+         transform="scale(-1)" />
+    </g>
+    <path
+       d="m 43.192212,29.585684 c -8.5,1.5 -21,1.5 -27,0 l -2.5,12.5 7.5,-11.5 2,5 3.5,-4.5 3,14.5 3,-14.5 3.5,4.5 2,-5 7.5,11.5 z"
+       stroke-linecap="butt"
+       id="path10984"
+       sodipodi:nodetypes="cccccccccccc"
+       style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+    <path
+       d="m 43.192212,29.585684 c 0,-2 -1.5,-2 -2.5,-4 -1,-1.5 -1,-1 -0.5,-3.5 1.5,-1 1.5,-2.5 1.5,-2.5 h -23.5 c 0,0 -0.5,1.5 1,2.5 0.5,2.5 0.5,2 -0.5,3.5 -1,2 -2.5,2 -2.5,4 8.5,1.5 18.5,1.5 27,0 z"
+       stroke-linecap="butt"
+       id="path10986"
+       sodipodi:nodetypes="ccccccccc"
+       style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+    <path
+       d="m 41.192212,26.585684 c -7.44776,2.590974 -15.55224,2.590974 -23,0 m 21.5,-2.5 c -6.946703,1.120144 -13.557044,0.894841 -20,0"
+       fill="none"
+       stroke="#ececec"
+       id="path10990"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g11069"
+     transform="matrix(0.45842563,0,0,0.45842563,-51.815396,3.9161049)"
+     style="display:inline">
+    <g
+       id="g4488-2"
+       transform="matrix(1.9382789,-0.51936028,0.51936028,1.9382789,99.026581,16.67806)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path980-1"
+         d="m 24.08171,16.068616 17.906034,15.25124 5.989759,-5.634783 C 46.920623,24.628194 33.456144,8.2310561 33.456144,8.2310561 26.117838,-1.6388799 16.26461,8.9163791 24.08171,16.068616 Z"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.37688;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path11057"
+       cx="-169.93221"
+       cy="-13.61842"
+       r="15.100924"
+       transform="scale(-1)" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 160.88993,18.171961 143.15687,17.790605 C 139.69971,7.3449081 132.6129,2.9486311 125.42382,-1.2771919 c 15.41624,0 17.09809,3.933397 22.30933,9.283403 l 12.9661,0.623091 z"
+       id="path11061"
+       sodipodi:nodetypes="cccccc" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:#eaeaea;stroke-width:3.89722;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="circle11059"
+       cx="-169.93221"
+       cy="-13.61842"
+       r="10.97773"
+       transform="scale(-1)" />
+  </g>
+</svg>

--- a/static/images/pieces/chennis/bFC_r.svg
+++ b/static/images/pieces/chennis/bFC_r.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg10994"
+   sodipodi:docname="bFC.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata11000">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10998" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2037"
+     id="namedview10996"
+     showgrid="false"
+     inkscape:zoom="7.919596"
+     inkscape:cx="45.26713"
+     inkscape:cy="36.116342"
+     inkscape:window-x="5749"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg10994"
+     inkscape:document-rotation="0" />
+  <g
+     id="g11069"
+     transform="matrix(0.31149041,0,0,0.31149041,-30.492973,1.5871307)"
+     style="display:inline;fill:#3e588a;fill-opacity:1">
+    <g
+       id="g4488-2"
+       transform="matrix(1.9382789,-0.51936028,0.51936028,1.9382789,99.026581,16.67806)"
+       style="fill:#3e588a;fill-opacity:1">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path980-1"
+         d="m 20.797635,46.559481 17.906034,15.25124 5.989759,-5.634783 C 43.636548,55.119059 30.172069,38.721921 30.172069,38.721921 c -7.338306,-9.869936 -17.191534,0.685323 -9.374434,7.83756 z"
+         style="fill:#3e588a;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <circle
+       style="fill:#3e588a;fill-opacity:1;stroke:none;stroke-width:3.37688;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path11057"
+       cx="-179.4025"
+       cy="-74.423836"
+       r="15.100924"
+       transform="scale(-1)" />
+    <path
+       style="fill:#3e588a;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 170.36022,78.97738 152.62716,78.596024 C 149.17,68.150327 142.08319,63.75405 134.89411,59.528227 c 15.41624,0 17.09809,3.933397 22.30933,9.283403 l 12.9661,0.623091 z"
+       id="path11061"
+       sodipodi:nodetypes="cccccc" />
+    <circle
+       style="fill:#3e588a;fill-opacity:1;stroke:#eaeaea;stroke-width:3.89722;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="circle11059"
+       cx="-179.4025"
+       cy="-74.423836"
+       r="10.97773"
+       transform="scale(-1)" />
+  </g>
+  <g
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g10992"
+     transform="translate(0,3)">
+    <g
+       stroke="none"
+       id="g10982">
+      <circle
+         cx="-39"
+         cy="-30"
+         r="2.75"
+         id="circle10972"
+         transform="scale(-1)" />
+      <circle
+         cx="-22.5"
+         cy="-34"
+         r="2.75"
+         id="circle10976"
+         transform="scale(-1)" />
+      <circle
+         cx="-6"
+         cy="-30"
+         r="2.75"
+         id="circle10980"
+         transform="scale(-1)" />
+    </g>
+    <path
+       d="M 36,16 C 27.5,17.5 15,17.5 9,16 L 6.5,28.5 14,17 l 2,5 3.5,-4.5 3,14.5 3,-14.5 3.5,4.5 2,-5 7.5,11.5 z"
+       stroke-linecap="butt"
+       id="path10984"
+       sodipodi:nodetypes="cccccccccccc" />
+    <path
+       d="M 36,16 C 36,14 34.5,14 33.5,12 32.5,10.5 32.5,11 33,8.5 34.5,7.5 34.5,6 34.5,6 H 11 c 0,0 -0.5,1.5 1,2.5 0.5,2.5 0.5,2 -0.5,3.5 -1,2 -2.5,2 -2.5,4 8.5,1.5 18.5,1.5 27,0 z"
+       stroke-linecap="butt"
+       id="path10986"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       d="m 34,13 c -7.44776,2.590974 -15.55224,2.590974 -23,0 m 21.5,-2.5 c -6.946703,1.120144 -13.557044,0.894841 -20,0"
+       fill="none"
+       stroke="#ececec"
+       id="path10990"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/static/images/pieces/chennis/bMN_r.svg
+++ b/static/images/pieces/chennis/bMN_r.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg4139"
+   sodipodi:docname="bMN.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata4145">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4143" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2037"
+     id="namedview4141"
+     showgrid="false"
+     inkscape:zoom="7.919596"
+     inkscape:cx="55.945226"
+     inkscape:cy="33.689137"
+     inkscape:window-x="5749"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4137"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g4137">
+    <g
+       fill="none"
+       fill-rule="evenodd"
+       stroke="#000000"
+       stroke-width="1.5"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       id="g5777"
+       transform="matrix(0.66106567,0,0,0.66106567,-0.17811383,-1.633082)">
+      <path
+         d="m 43.810386,59.796004 c -10.5,-1 -16.5,-8 -16,-29 h 23 c 0,9 -10,6.5 -8,21"
+         fill="#000000"
+         id="path5769"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="m 41.810386,51.796004 c -0.38,-2.91 5.55,-7.37 8,-9 3,-2 2.82,-4.34 5,-4 1.042,0.94 -1.41,3.04 0,3 1,0 -0.19,-1.23 1,-2 1,0 4.003,-1 4,4 0,2 -6,12 -6,12 0,0 -1.89,1.9 -2,3.5 0.73,0.994 0.5,2 0.5,3 -1,1 -3,-2.5 -3,-2.5 h -2 c 0,0 -0.78,1.992 -2.5,3 -1,0 -1,-3 -1,-3"
+         fill="#000000"
+         id="path5771"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="m 56.310386,44.296004 a -0.5,-0.5 0 1 1 1,0 -0.5,-0.5 0 1 1 -1,0 z m -5.433,9.75 a 0.5,1.5 30 1 1 0.866,0.5 0.5,1.5 30 1 1 -0.866,-0.5 z"
+         fill="#ececec"
+         stroke="#ececec"
+         id="path5773" />
+      <path
+         d="m 41.260386,59.396004 0.45,-1.45 -0.5,-0.15 c -3.15,-1 -5.65,-2.49 -7.9,-6.75 -2.25,-4.26 -3.25,-10.31 -2.75,-20.25 l 0.05,-0.5 h -2.25 l -0.05,0.5 c -0.5,10.06 0.88,16.85 3.25,21.34 2.37,4.49 5.79,6.64 9.19,7.16 z"
+         fill="#ececec"
+         stroke="none"
+         id="path5775" />
+    </g>
+    <path
+       d="m 20.64876,23.675578 c 0,0 -4.5,7.5 -3,10.5 0,0 1,2.5 3,2.5 2,0 3,-2.5 3,-2.5 1.5,-3 -3,-10.5 -3,-10.5"
+       fill="#000000"
+       stroke-linecap="butt"
+       stroke-linejoin="miter"
+       id="path4127"
+       sodipodi:nodetypes="ccscc" />
+    <path
+       d="m 31.64876,5.8735784 c -5.5,-3.5 -15.5,-3.5 -21,0 v 6.9999996 c 0,0 -9.0000004,4.5 -6.0000004,10.5 4,6.5 13.5000004,4.257 16.5000004,4.257 3,0 12.5,2.243 15.5,-4.257 3,-6 -5,-10 -5,-10 z"
+       fill="#000000"
+       id="path4129"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       d="m 11.14876,13.373578 c 0,0 -8.5000004,4 -6.0300004,9.65 3.88,5.85 13.0300004,3.554632 15.5300004,3.554632 2.5,0 12.594,2.295368 15.503,-3.554632 2.497,-5.65 -4.853,-9 -4.853,-9"
+       stroke="#ececec"
+       id="path4133"
+       sodipodi:nodetypes="ccccc"
+       style="stroke:#ededed;stroke-opacity:1" />
+    <path
+       d="m 31.64876,12.873578 c -5.5,3 -15.5,3 -21,0 m 21,-3.4999996 c -5.5,2.9999996 -15.5,2.9999996 -21,0 m 21,-3.5 c -5.5,3 -15.5,3 -21,0"
+       stroke="#ececec"
+       id="path4135"
+       style="stroke:#ededed;stroke-opacity:1" />
+  </g>
+</svg>

--- a/static/images/pieces/chennis/bNM_r.svg
+++ b/static/images/pieces/chennis/bNM_r.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg9534"
+   sodipodi:docname="bNM.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata9540">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs9538" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview9536"
+     showgrid="false"
+     inkscape:zoom="22.627416"
+     inkscape:cx="-2.0541963"
+     inkscape:cy="27.943608"
+     inkscape:window-x="-12"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg9534"
+     inkscape:document-rotation="0" />
+  <g
+     id="g10736"
+     transform="matrix(0.75,0,0,0.75,13.11075,23.35875)">
+    <path
+       d="m 12.942172,14.797503 c 0,0 -4.4999997,1.557497 -2.9999997,4.557497 0,0 0.9999997,2.5 2.9999997,2.5 2,0 3,-2.5 3,-2.5 1.5,-3 -3,-4.557497 -3,-4.557497"
+       fill="#000000"
+       stroke-linecap="butt"
+       stroke-linejoin="miter"
+       id="path4127"
+       sodipodi:nodetypes="ccscc"
+       style="fill:#3e588a;fill-opacity:1" />
+    <path
+       d="m 23.942172,0.495829 c -5.863082,3.5800921 -15.8094587,2.5344456 -20.9999997,0 v 3.4996738 c 0,0 -9,4.5000002 -6,10.5000002 3.99999997,6.5 13.4999997,4.257 16.4999997,4.257 3,0 12.5,2.243 15.5,-4.257 3,-6 -5,-10.0000002 -5,-10.0000002 z"
+       fill="#000000"
+       id="path4129"
+       sodipodi:nodetypes="cccccccc"
+       style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 3.4421723,4.4955028 c 0,0 -8.5,4.0000002 -6.03,9.6500002 3.88,5.85 13.0299997,3.554632 15.5299997,3.554632 2.5,0 12.594,2.295368 15.503,-3.554632 2.497,-5.65 -4.853,-9.0000002 -4.853,-9.0000002"
+       stroke="#ececec"
+       id="path4133"
+       sodipodi:nodetypes="ccccc"
+       style="fill:#3e588a;fill-opacity:1;stroke:#ececec;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 23.942172,3.9955028 c -5.5,3.0000002 -15.4999997,3.0000002 -20.9999997,0"
+       stroke="#ececec"
+       id="path4135"
+       style="fill:none;stroke:#ececec;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 23.942172,0.495829 c -5.5,3.0000002 -15.4999997,3.0000002 -20.9999997,0"
+       stroke="#ececec"
+       id="path10758"
+       style="fill:none;stroke:#ececec;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g9532"
+     transform="matrix(0.75,0,0,0.75,5.6766591,9.9375)">
+    <path
+       d="m 23.854293,22.390829 c -10.5,-1 -16.5000003,-8 -16.0000003,-29 H 30.854293 c 0,9 -10,6.5 -8,21"
+       fill="#000000"
+       id="path9524" />
+    <path
+       d="m 21.854293,14.390829 c -0.38,-2.91 5.55,-7.37 8,-9 3,-2 2.82,-4.34 5,-4 1.042,0.94 -1.41,3.04 0,3 1,0 -0.19,-1.23 1,-2 1,0 4.003,-1 4,4 0,2 -6,12 -6,12 0,0 -1.89,1.9 -2,3.5 0.73,0.994 0.5,2 0.5,3 -1,1 -3,-2.5 -3,-2.5 h -2 c 0,0 -0.78,1.992 -2.5,3 -1,0 -1,-3 -1,-3"
+       fill="#000000"
+       id="path9526" />
+    <path
+       d="m 36.354293,6.890829 a -0.5,-0.5 0 1 1 1,0 -0.5,-0.5 0 1 1 -1,0 z m -5.433,9.75 a 0.5,1.5 30 1 1 0.866,0.5 0.5,1.5 30 1 1 -0.866,-0.5 z"
+       fill="#ececec"
+       stroke="#ececec"
+       id="path9528"
+       style="stroke:#ececec;stroke-opacity:1" />
+  </g>
+  <path
+     d="m 22.012825,26.597651 0.337496,-1.087501 -0.374999,-0.112501 c -2.3625,-0.75 -4.237501,-1.8675 -5.925,-5.0625 -1.687501,-3.195 -2.437501,-7.7325 -2.062501,-15.1875003 l 0.0375,-0.374999 h -1.687499 l -0.0375,0.375002 c -0.375006,7.5449993 0.659994,12.6374993 2.437495,16.0049993 1.777499,3.3675 4.342499,4.979999 6.892499,5.37 z"
+     fill="#ececec"
+     stroke="none"
+     id="path7081"
+     style="stroke-width:0.75" />
+</svg>

--- a/static/images/pieces/chennis/bPR_r.svg
+++ b/static/images/pieces/chennis/bPR_r.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg5296"
+   sodipodi:docname="bPR.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata5302">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5300" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview5298"
+     showgrid="false"
+     inkscape:zoom="15.839192"
+     inkscape:cx="7.3141653"
+     inkscape:cy="29.379564"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5296"
+     inkscape:document-rotation="0" />
+  <g
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g4679"
+     transform="matrix(0.94936578,0,0,0.94936578,1.1392699,-1.6097587)"
+     style="fill:#d35f5f;fill-opacity:1">
+    <g
+       id="g5913"
+       transform="matrix(1.0422234,0,0,1.0422234,-0.95002645,0.11627868)">
+      <path
+         d="M 36,11.444467 H 9 v 3 h 27 z m -3.5,7 -1.5,2.5 H 14 l -1.5,-2.5 z m 0.5,-4 v 4 H 12 v -4 z"
+         stroke-linecap="butt"
+         id="path4671"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="m 31,20.944467 v 13 H 14 v -13 z"
+         stroke-linecap="butt"
+         stroke-linejoin="miter"
+         id="path4673"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="m 31,33.944467 3,2.5 H 11 l 3,-2.5 z m 3,2.5 v 5 h -4 v -2 h -5 v 2 h -5 v -2 h -5 v 2 h -4 v -5 z"
+         stroke-linecap="butt"
+         id="path4675"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="M 33,14.944467 H 12 m 20,4 H 13 m 18,2 H 14 m 17,13 H 14 m 20,2.5 H 11"
+         fill="none"
+         stroke="#ececec"
+         stroke-width="1"
+         stroke-linejoin="miter"
+         id="path4677"
+         style="fill:#d35f5f;fill-opacity:1" />
+    </g>
+  </g>
+  <path
+     d="m 22.5,37.913605 c 2.21,0 4,-1.79 4,-4 0,-0.89 -0.29,-1.71 -0.78,-2.38 1.95,-1.12 3.28,-3.21 3.28,-5.62 0,-2.03 -0.94,-3.84 -2.41,-5.03 3,-1.06 7.41,-5.55 7.41,-13.47 H 11 c 0,7.92 4.41,12.41 7.41,13.47 -1.47,1.19 -2.41,3 -2.41,5.03 0,2.41 1.33,4.5 3.28,5.62 -0.49,0.67 -0.78,1.49 -0.78,2.38 0,2.21 1.79,4 4,4 z"
+     fill="#fff"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     id="path5294"
+     style="fill:#000000" />
+</svg>

--- a/static/images/pieces/chennis/bRP_r.svg
+++ b/static/images/pieces/chennis/bRP_r.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg4681"
+   sodipodi:docname="bRP.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata4687">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4685" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview4683"
+     showgrid="false"
+     inkscape:zoom="22.4"
+     inkscape:cx="22.5"
+     inkscape:cy="22.5"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4681"
+     inkscape:document-rotation="0" />
+  <g
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g4679">
+    <path
+       d="M 36,9 H 9 v 3 H 36 Z M 32.5,16 31,18.5 H 14 L 12.5,16 Z M 33,12 v 4 H 12 v -4 z"
+       stroke-linecap="butt"
+       id="path4671" />
+    <path
+       d="m 31,18.5 v 13 H 14 v -13 z"
+       stroke-linecap="butt"
+       stroke-linejoin="miter"
+       id="path4673" />
+    <path
+       d="M 31,31.5 34,34 H 11 l 3,-2.5 z m 3,2.5 v 5 h -4 v -2 h -5 v 2 h -5 v -2 h -5 v 2 h -4 v -5 z"
+       stroke-linecap="butt"
+       id="path4675" />
+    <path
+       d="M 33,12.5 H 12 m 20,4 H 13 m 18,2 H 14 m 17,13 H 14 M 34,34 H 11"
+       fill="none"
+       stroke="#ececec"
+       stroke-width="1"
+       stroke-linejoin="miter"
+       id="path4677" />
+  </g>
+  <path
+     d="m 22.5,30.25349 c 0.93471,0 1.691783,-0.757073 1.691783,-1.691782 0,-0.376422 -0.122654,-0.723238 -0.329898,-1.006611 0.824744,-0.473698 1.387261,-1.357655 1.387261,-2.376953 0,-0.85858 -0.397569,-1.62411 -1.019299,-2.127417 1.268837,-0.448321 3.134027,-2.347346 3.134027,-5.697075 h -9.727747 c 0,3.349729 1.865189,5.248754 3.134025,5.697075 -0.621729,0.503307 -1.019298,1.268837 -1.019298,2.127417 0,1.019298 0.562517,1.903255 1.387261,2.376953 -0.207243,0.283373 -0.329897,0.630189 -0.329897,1.006611 0,0.934709 0.757073,1.691782 1.691782,1.691782 z"
+     stroke="#000000"
+     stroke-width="0.634419"
+     stroke-linecap="round"
+     id="path4028"
+     style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+</svg>

--- a/static/images/pieces/chennis/bSB_r.svg
+++ b/static/images/pieces/chennis/bSB_r.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="bSB.svg"
+   id="svg3845"
+   version="1.1"
+   height="45"
+   width="45">
+  <metadata
+     id="metadata3851">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3849">
+    <inkscape:path-effect
+       split_items="false"
+       oposite_fuse="false"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect4448"
+       center_point="-103.61098,72.03113"
+       end_point="-103.61098,147.39645"
+       start_point="-103.61098,-3.3341899"
+       effect="mirror_symmetry" />
+    <inkscape:path-effect
+       effect="mirror_symmetry"
+       start_point="-103.61098,-3.3341899"
+       end_point="-103.61098,147.39645"
+       center_point="-103.61098,72.03113"
+       id="path-effect4256"
+       is_visible="true"
+       lpeversion="1"
+       mode="free"
+       discard_orig_path="false"
+       fuse_paths="true"
+       oposite_fuse="false"
+       split_items="false" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:current-layer="svg3845"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-12"
+     inkscape:window-x="3828"
+     inkscape:cy="51.618824"
+     inkscape:cx="3.7216219"
+     inkscape:zoom="4.8222222"
+     showgrid="false"
+     id="namedview3847"
+     inkscape:window-height="2050"
+     inkscape:window-width="3840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g2116"
+     transform="matrix(0.83211331,0,0,0.83211331,3.7774503,-0.33748681)">
+    <g
+       fill="#000000"
+       stroke-linecap="butt"
+       id="g2112">
+      <path
+         d="m 35.999995,17.615758 c -3.39,0.97 -10.11,-0.43 -13.5,2 -3.39,-2.43 -10.11,-1.03 -13.4999997,-2 0,0 -1.65,-0.54 -3,-2 0.68,-0.97 1.65,-0.99 3,-0.5 3.3899997,0.97 10.1099997,-0.46 13.4999997,1 3.39,-1.46 10.11,-0.03 13.5,-1 1.354,-0.49 2.323,-0.47 3,0.5 -1.354,1.94 -3,2 -3,2 z"
+         id="path2106"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="m 29.999995,21.615758 c -2.5,-2.5 -12.5,-2.5 -15,0 -0.5,1.5 0,2 0,2 0,2.5 2.5,4 2.5,4 -5.5,1.5 -6,11.5 5,15.5 11,-4 10.5,-14 5,-15.5 0,0 2.5,-1.5 2.5,-4 0,0 0.5,-0.5 0,-2 z"
+         id="path2108"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+      <path
+         d="m 19.999995,45.615758 a -2.5,-2.5 0 1 1 5,0 -2.5,-2.5 0 1 1 -5,0 z"
+         id="path2110"
+         style="fill:#3e588a;fill-opacity:1;stroke:#3e588a;stroke-opacity:1" />
+    </g>
+    <path
+       d="m 27.499995,27.615758 h -10 m 12.5,-4 h -15"
+       stroke="#ececec"
+       stroke-linejoin="miter"
+       id="path2114"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <path
+     inkscape:path-effect="#path-effect4448"
+     inkscape:original-d="M -99.745078,-1.3007197 C -105.01077,33.87678 -149.43162,66.260788 -162.80489,77.273131 c 23.39443,-1.486303 41.84318,-5.969219 49.87893,-5.905687 -3.78985,50.016626 -46.94654,39.365156 -46.95985,71.818166 33.16237,0 80.332875,-0.35352 115.78722,-0.35352 -0.006,-11.54918 -5.174356,-28.25734 -18.099609,-30.09179 -44.142831,-81.107313 6.642805,-43.090295 -37.546879,-114.0410197 z"
+     transform="matrix(-0.21423887,0,0,-0.21423887,0.30249665,35.040976)"
+     id="path2176-6"
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:7.00153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m -103.61098,12.19137 c -12.38926,29.718231 -47.55333,55.496217 -59.19391,65.081761 23.39443,-1.486303 41.84318,-5.969219 49.87893,-5.905687 -3.78985,50.016626 -46.94654,39.365156 -46.95985,71.818166 16.37512,0 36.16578,-0.0862 56.27483,-0.17347 20.10905,0.0873 39.899706,0.17347 56.27483,0.17347 -0.01331,-32.45301 -43.17,-21.80154 -46.95985,-71.818166 8.03575,-0.06353 26.4845,4.419384 49.87893,5.905687 -11.64058,-9.585544 -46.804652,-35.36353 -59.19391,-65.081761 z"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/static/images/pieces/chennis/wBS_r.svg
+++ b/static/images/pieces/chennis/wBS_r.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg902"
+   sodipodi:docname="wBS.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata908">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs906">
+    <inkscape:path-effect
+       split_items="false"
+       oposite_fuse="false"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect4448"
+       center_point="-103.61098,72.03113"
+       end_point="-103.61098,147.39645"
+       start_point="-103.61098,-3.3341899"
+       effect="mirror_symmetry" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview904"
+     showgrid="false"
+     inkscape:zoom="11.2"
+     inkscape:cx="-7.962508"
+     inkscape:cy="23.767474"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg902"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g900">
+    <g
+       fill="#fff"
+       stroke-linecap="butt"
+       id="g896">
+      <path
+         d="m 35.999995,8.3163007 c -3.39,0.97 -10.11,-0.43 -13.5,2.0000003 -3.39,-2.4300003 -10.11,-1.0300003 -13.4999997,-2.0000003 0,0 -1.65,-0.54 -3,-2 0.68,-0.97 1.65,-0.99 3,-0.5 3.3899997,0.97 10.1099997,-0.46 13.4999997,1 3.39,-1.46 10.11,-0.03 13.5,-1 1.354,-0.49 2.323,-0.47 3,0.5 -1.354,1.94 -3,2 -3,2 z"
+         id="path890" />
+      <path
+         d="m 29.999995,12.316301 c -2.5,-2.5000003 -12.5,-2.5000003 -15,0 -0.5,1.5 0,2 0,2 0,2.5 2.5,4 2.5,4 -5.5,1.5 -6,11.5 5,15.5 11,-4 10.5,-14 5,-15.5 0,0 2.5,-1.5 2.5,-4 0,0 0.5,-0.5 0,-2 z"
+         id="path892" />
+      <path
+         d="m 19.999995,36.316301 a -2.5,-2.5 0 1 1 5,0 -2.5,-2.5 0 1 1 -5,0 z"
+         id="path894" />
+    </g>
+    <path
+       d="m 27.499995,18.316301 h -10 m 12.5,-4 h -15"
+       stroke-linejoin="miter"
+       id="path898"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <path
+     id="path2176-6"
+     style="fill:#d35f5f;fill-opacity:1;stroke:none;stroke-width:0.651777;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 22.439103,32.366247 c 1.15332,-2.766482 4.426759,-5.166165 5.510386,-6.058489 -2.177797,0.138362 -3.895198,0.555678 -4.643251,0.549764 0.352799,-4.656068 4.370273,-3.664518 4.371512,-6.685584 -1.524366,0 -3.366686,0.0081 -5.238647,0.01616 -1.87196,-0.0081 -3.714279,-0.01616 -5.238647,-0.01616 0.0013,3.021066 4.018713,2.029516 4.371511,6.685584 -0.748052,0.0059 -2.465453,-0.411402 -4.643249,-0.549764 1.083626,0.892324 4.357065,3.292007 5.510385,6.058489 z"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/static/images/pieces/chennis/wCF_r.svg
+++ b/static/images/pieces/chennis/wCF_r.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg6582"
+   sodipodi:docname="wCF.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata6588">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6586">
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4403"
+       x="-1.08e-05"
+       width="1.0000216"
+       y="-1.08e-05"
+       height="1.0000216">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.475e-05"
+         id="feGaussianBlur4405" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview6584"
+     showgrid="false"
+     inkscape:zoom="3.409826"
+     inkscape:cx="109.11889"
+     inkscape:cy="129.85551"
+     inkscape:window-x="-12"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6582" />
+  <g
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g10992"
+     transform="matrix(0.6453104,0.37257013,-0.37257013,0.6453104,17.519228,-4.6935226)">
+    <g
+       stroke="none"
+       id="g10982">
+      <circle
+         cx="-49.026875"
+         cy="-43.11132"
+         r="2.75"
+         id="circle10972"
+         style="fill:#d35f5f;fill-opacity:1"
+         transform="scale(-1)" />
+      <circle
+         cx="22.5"
+         cy="8"
+         r="2.75"
+         id="circle10976"
+         style="fill:#d35f5f;fill-opacity:1;filter:url(#filter4403)"
+         transform="rotate(180,27.513438,27.555661)" />
+      <circle
+         cx="-16.026876"
+         cy="-43.11132"
+         r="2.75"
+         id="circle10980"
+         style="fill:#d35f5f;fill-opacity:1"
+         transform="scale(-1)" />
+    </g>
+    <path
+       d="m 46.026876,29.111321 c -8.5,1.5 -21,1.5 -27,0 l -2.5,12.5 7.5,-11.5 2,5 3.5,-4.5 3,14.5 3,-14.5 3.5,4.5 2,-5 7.5,11.5 z"
+       stroke-linecap="butt"
+       id="path10984"
+       sodipodi:nodetypes="cccccccccccc"
+       style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+    <path
+       d="m 46.026876,29.111321 c 0,-2 -1.5,-2 -2.5,-4 -1,-1.5 -1,-1 -0.5,-3.5 1.5,-1 1.5,-2.5 1.5,-2.5 h -23.5 c 0,0 -0.5,1.5 1,2.5 0.5,2.5 0.5,2 -0.5,3.5 -1,2 -2.5,2 -2.5,4 8.5,1.5 18.5,1.5 27,0 z"
+       stroke-linecap="butt"
+       id="path10986"
+       sodipodi:nodetypes="ccccccccc"
+       style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+    <path
+       d="m 44.026876,26.111321 c -7.44776,2.590974 -15.55224,2.590974 -23,0 m 21.5,-2.5 c -6.946703,1.120144 -13.557044,0.894841 -20,0"
+       fill="none"
+       stroke="#ececec"
+       id="path10990"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g4488-2"
+     transform="matrix(0.88855673,-0.23808806,0.23808806,0.88855673,-6.4190732,11.561755)"
+     style="stroke-width:1.63060916;stroke-miterlimit:4;stroke-dasharray:none;paint-order:normal">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path980-1"
+       d="m 25.977028,17.42053 17.906034,15.25124 5.989759,-5.634783 C 48.815941,25.980108 35.351462,9.5829697 35.351462,9.5829697 28.013156,-0.28696627 18.159928,10.268293 25.977028,17.42053 Z"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.63061;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal" />
+  </g>
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#1a1a1a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 23.946644,12.996597 -8.12929,-0.174823 C 14.232504,8.033199 10.983728,6.017833 7.6880703,4.080607 c 7.0671987,0 7.8382017,1.80317 10.2271677,4.25575 l 5.943993,0.285641 z"
+     id="path11061"
+     sodipodi:nodetypes="cccccc" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="path11057"
+     cx="-28.091852"
+     cy="-10.909138"
+     r="6.9226503"
+     transform="scale(-1)" />
+  <circle
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.602287;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+     id="circle11059"
+     cx="-28.091852"
+     cy="-10.909138"
+     r="1.6965253"
+     transform="scale(-1)" />
+</svg>

--- a/static/images/pieces/chennis/wFC_r.svg
+++ b/static/images/pieces/chennis/wFC_r.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg10994"
+   sodipodi:docname="wFC.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata11000">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10998" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2037"
+     id="namedview10996"
+     showgrid="false"
+     inkscape:zoom="7.919596"
+     inkscape:cx="45.26713"
+     inkscape:cy="36.116342"
+     inkscape:window-x="5749"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg10994"
+     inkscape:document-rotation="0" />
+  <g
+     id="g11069"
+     transform="matrix(0.31149041,0,0,0.31149041,-30.492973,1.5871307)"
+     style="display:inline;fill:#d35f5f;fill-opacity:1">
+    <g
+       id="g4488-2"
+       transform="matrix(1.9382789,-0.51936028,0.51936028,1.9382789,99.026581,16.67806)"
+       style="fill:#d35f5f;fill-opacity:1">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path980-1"
+         d="m 21.004672,45.786808 17.906034,15.25124 5.989759,-5.634783 C 43.843585,54.346386 30.379106,37.949248 30.379106,37.949248 23.0408,28.079312 13.187572,38.634571 21.004672,45.786808 Z"
+         style="fill:#d35f5f;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <circle
+       style="fill:#d35f5f;fill-opacity:1;stroke:none;stroke-width:3.37688;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path11057"
+       cx="-179.4025"
+       cy="-72.818657"
+       r="15.100924"
+       transform="scale(-1)" />
+    <path
+       style="fill:#d35f5f;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 170.36022,77.372197 152.62716,76.990841 C 149.17,66.545144 142.08319,62.148867 134.89411,57.923044 c 15.41624,0 17.09809,3.933397 22.30933,9.283403 l 12.9661,0.623091 z"
+       id="path11061"
+       sodipodi:nodetypes="cccccc" />
+    <circle
+       style="fill:#d35f5f;fill-opacity:1;stroke:#eaeaea;stroke-width:3.89722;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="circle11059"
+       cx="-179.4025"
+       cy="-72.818657"
+       r="10.97773"
+       transform="scale(-1)" />
+  </g>
+  <g
+     fill="#ffffff"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g10371"
+     transform="translate(0,3)">
+    <path
+       d="m 37,29.500001 c 0,-2.666666 4,-2.666666 4,0 0,2.666665 -4,2.666665 -4,0 z m -16.5,4.5 c 0,-2.666666 4,-2.666666 4,0 0,2.666665 -4,2.666665 -4,0 z m -16.5,-4.5 c 0,-2.666666 4,-2.666666 4,0 0,2.666665 -4,2.666665 -4,0 z"
+       id="path10363"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       d="m 36,15.500001 c -8.5,1.5 -21,1.5 -27,0 l -2,12 7,-11 2,5 3.5,-4.5 3,15 3,-15 3.5,4.5 2,-5 7,11 z"
+       stroke-linecap="butt"
+       id="path10365"
+       sodipodi:nodetypes="cccccccccccc" />
+    <path
+       d="m 36,15.500001 c 0,-2 -1.5,-2 -2.5,-4 -1,-1.5 -1,-1 -0.5,-3.5000001 1.5,-1 1.5,-2.5 1.5,-2.5 H 11 c 0,0 -0.5,1.5 1,2.5 0.5,2.5000001 0.5,2.0000001 -0.5,3.5000001 -1,2 -2.5,2 -2.5,4 8.5,1.5 18.5,1.5 27,0 z"
+       stroke-linecap="butt"
+       id="path10367"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       d="m 33.5,11.500001 c -3.5,1 -18.5,1 -22,0 M 33,8.0000009 c -6,1 -15,1 -21,0"
+       fill="none"
+       id="path10369" />
+  </g>
+</svg>

--- a/static/images/pieces/chennis/wMN_r.svg
+++ b/static/images/pieces/chennis/wMN_r.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg22457"
+   sodipodi:docname="wMN.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata22463">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22461" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview22459"
+     showgrid="false"
+     inkscape:zoom="7.919596"
+     inkscape:cx="11.962679"
+     inkscape:cy="22.43519"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg22457"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g5777"
+     transform="matrix(0.66106567,0,0,0.66106567,-0.28470897,-1.5142805)">
+    <path
+       d="m 43.971634,59.616292 c -10.5,-1 -16.5,-8 -16,-29 h 23 c 0,9 -10,6.5 -8,21"
+       fill="#000000"
+       id="path5769"
+       style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+    <path
+       d="m 41.971634,51.616292 c -0.38,-2.91 5.55,-7.37 8,-9 3,-2 2.82,-4.34 5,-4 1.042,0.94 -1.41,3.04 0,3 1,0 -0.19,-1.23 1,-2 1,0 4.003,-1 4,4 0,2 -6,12 -6,12 0,0 -1.89,1.9 -2,3.5 0.73,0.994 0.5,2 0.5,3 -1,1 -3,-2.5 -3,-2.5 h -2 c 0,0 -0.78,1.992 -2.5,3 -1,0 -1,-3 -1,-3"
+       fill="#000000"
+       id="path5771"
+       style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+    <path
+       d="m 56.471634,44.116292 a -0.5,-0.5 0 1 1 1,0 -0.5,-0.5 0 1 1 -1,0 z m -5.433,9.75 a 0.5,1.5 30 1 1 0.866,0.5 0.5,1.5 30 1 1 -0.866,-0.5 z"
+       fill="#ececec"
+       stroke="#ececec"
+       id="path5773" />
+    <path
+       d="m 41.421634,59.216292 0.45,-1.45 -0.5,-0.15 c -3.15,-1 -5.65,-2.49 -7.9,-6.75 -2.25,-4.26 -3.25,-10.31 -2.75,-20.25 l 0.05,-0.5 h -2.25 l -0.05,0.5 c -0.5,10.06 0.88,16.85 3.25,21.34 2.37,4.49 5.79,6.64 9.19,7.16 z"
+       fill="#ececec"
+       stroke="none"
+       id="path5775" />
+  </g>
+  <path
+     d="m 20.573571,23.169411 c 0,0 -4.5,7.5 -3,10.500001 0,0 1,2.5 3,2.5 2,0 3,-2.5 3,-2.5 1.5,-3.000001 -3,-10.500001 -3,-10.500001"
+     fill="#ffffff"
+     stroke-linecap="butt"
+     stroke-linejoin="miter"
+     id="path22449"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.5" />
+  <path
+     d="m 31.542164,5.9923799 c -5.5,-3.5 -15.5,-3.5 -21,0 V 12.99238 c 0,0 -8.9999996,4.5 -5.9999996,10.5 4,6.5 13.6262686,3.631526 16.6262686,3.631526 3,0 12.373731,2.868474 15.373731,-3.631526 3,-6 -5,-10 -5,-10 z"
+     fill="#ffffff"
+     id="path22451"
+     sodipodi:nodetypes="cccccccc"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round" />
+  <path
+     d="m 31.542164,12.99238 c -5.5,3 -15.5,3 -21,0 m 21,-3.5000001 c -5.5,3.0000001 -15.5,3.0000001 -21,0 m 21,-3.5 c -5.5,3 -15.5,3 -21,0"
+     id="path22453"
+     style="fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round" />
+</svg>

--- a/static/images/pieces/chennis/wNM_r.svg
+++ b/static/images/pieces/chennis/wNM_r.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg8937"
+   sodipodi:docname="wNM.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata8943">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8941" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1918"
+     inkscape:window-height="2037"
+     id="namedview8939"
+     showgrid="false"
+     inkscape:zoom="11.2"
+     inkscape:cx="11.356234"
+     inkscape:cy="50.406661"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8935"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g8935"
+     transform="matrix(0.75,0,0,0.75,5.2735551,9.75)"
+     style="stroke:#000080;stroke-opacity:1">
+    <g
+       id="g10736"
+       transform="translate(9.880715,17.832216)">
+      <path
+         d="m 12.723578,14.360287 c 0,0 -4.4999995,1.557497 -2.9999995,4.557497 0,0 0.9999995,2.5 2.9999995,2.5 2,0 3,-2.5 3,-2.5 1.5,-3 -3,-4.557497 -3,-4.557497"
+         fill="#000000"
+         stroke-linecap="butt"
+         stroke-linejoin="miter"
+         id="path4127"
+         sodipodi:nodetypes="ccscc"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+      <path
+         d="m 23.723578,0.058613 c -5.863081,3.5800921 -15.8094585,2.5344456 -20.9999995,0 v 3.4996738 c 0,0 -9,4.5000002 -6,10.5000002 3.99999995,6.5 13.4999995,4.257 16.4999995,4.257 3,0 12.5,2.243 15.5,-4.257 3,-6 -5,-10.0000002 -5,-10.0000002 z"
+         fill="#000000"
+         id="path4129"
+         sodipodi:nodetypes="cccccccc"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         d="m 3.2235785,4.0582868 c 0,0 -8.5,4.0000002 -6.03,9.6500002 3.88,5.85 13.0299995,3.554632 15.5299995,3.554632 2.5,0 12.594,2.295368 15.503,-3.554632 2.497,-5.65 -4.853,-9.0000002 -4.853,-9.0000002"
+         stroke="#ececec"
+         id="path4133"
+         sodipodi:nodetypes="ccccc"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#ececec;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         d="m 23.723578,3.5582868 c -5.5,3.0000002 -15.4999995,3.0000002 -20.9999995,0"
+         stroke="#ececec"
+         id="path4135"
+         style="fill:none;stroke:#ececec;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         d="m 23.723578,0.058613 c -5.5,3.0000002 -15.4999995,3.0000002 -20.9999995,0"
+         stroke="#ececec"
+         id="path10758"
+         style="fill:none;stroke:#ececec;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       d="m 23.572886,21.828045 c -10.5,-1 -16.4999995,-8 -15.9999995,-29 H 30.572886 c 0,9 -10,6.5 -8,21"
+       fill="#ffffff"
+       id="path8929"
+       style="stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 21.572886,13.828045 c -0.38,-2.91 5.55,-7.37 8,-9 3,-2 2.82,-4.34 5,-4 1.042,0.94 -1.295259,2.105477 0.114741,2.065477 1,0 -0.304741,-0.295477 0.885259,-1.065477 1,0 4.003,-1 4,4 0,2 -6,12 -6,12 0,0 -1.89,1.9 -2,3.5 0.73,0.994 0.5,2 0.5,3 -1,1 -3,-2.5 -3,-2.5 h -2 c 0,0 -0.78,1.992 -2.5,3 -1,0 -1,-3 -1,-3"
+       fill="#ffffff"
+       id="path8931"
+       style="stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       d="m 36.072886,6.328045 a -0.5,-0.5 0 1 1 1,0 -0.5,-0.5 0 1 1 -1,0 z m -5.433,9.75 a 0.5,1.5 30 1 1 0.866,0.5 0.5,1.5 30 1 1 -0.866,-0.5 z"
+       fill="#000"
+       id="path8933"
+       style="fill:#000080;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/static/images/pieces/chennis/wPR_r.svg
+++ b/static/images/pieces/chennis/wPR_r.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg5296"
+   sodipodi:docname="wPR.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata5302">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5300" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview5298"
+     showgrid="false"
+     inkscape:zoom="7.919596"
+     inkscape:cx="16.929634"
+     inkscape:cy="32.86946"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5296"
+     inkscape:document-rotation="0" />
+  <g
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g4679"
+     transform="matrix(0.94936578,0,0,0.94936578,1.1392699,-1.6097587)"
+     style="fill:#d35f5f;fill-opacity:1">
+    <g
+       id="g5913"
+       transform="matrix(1.0422234,0,0,1.0422234,-0.95002645,0.11627868)">
+      <path
+         d="M 36,11.444467 H 9 v 3 h 27 z m -3.5,7 -1.5,2.5 H 14 l -1.5,-2.5 z m 0.5,-4 v 4 H 12 v -4 z"
+         stroke-linecap="butt"
+         id="path4671"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+      <path
+         d="m 31,20.944467 v 13 H 14 v -13 z"
+         stroke-linecap="butt"
+         stroke-linejoin="miter"
+         id="path4673"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+      <path
+         d="m 31,33.944467 3,2.5 H 11 l 3,-2.5 z m 3,2.5 v 5 h -4 v -2 h -5 v 2 h -5 v -2 h -5 v 2 h -4 v -5 z"
+         stroke-linecap="butt"
+         id="path4675"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+      <path
+         d="M 33,14.944467 H 12 m 20,4 H 13 m 18,2 H 14 m 17,13 H 14 m 20,2.5 H 11"
+         fill="none"
+         stroke="#ececec"
+         stroke-width="1"
+         stroke-linejoin="miter"
+         id="path4677"
+         style="fill:#d35f5f;fill-opacity:1" />
+    </g>
+  </g>
+  <path
+     d="m 22.5,37.913605 c 2.21,0 4,-1.79 4,-4 0,-0.89 -0.29,-1.71 -0.78,-2.38 1.95,-1.12 3.28,-3.21 3.28,-5.62 0,-2.03 -0.94,-3.84 -2.41,-5.03 3,-1.06 7.41,-5.55 7.41,-13.47 H 11 c 0,7.92 4.41,12.41 7.41,13.47 -1.47,1.19 -2.41,3 -2.41,5.03 0,2.41 1.33,4.5 3.28,5.62 -0.49,0.67 -0.78,1.49 -0.78,2.38 0,2.21 1.79,4 4,4 z"
+     fill="#ffffff"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     id="path5294" />
+</svg>

--- a/static/images/pieces/chennis/wRP_r.svg
+++ b/static/images/pieces/chennis/wRP_r.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg3449"
+   sodipodi:docname="wRP.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata3455">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3453" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2050"
+     id="namedview3451"
+     showgrid="false"
+     inkscape:zoom="11.2"
+     inkscape:cx="-5.2560949"
+     inkscape:cy="16.191539"
+     inkscape:window-x="3828"
+     inkscape:window-y="-12"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3449"
+     inkscape:document-rotation="0" />
+  <g
+     fill="#fff"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g3447">
+    <path
+       d="M 36,9 H 9 v 3 h 27 z m -3,3 v 4 H 12 v -4 z m 1,22 v 5 h -4 v -2 h -5 v 2 h -5 v -2 h -5 v 2 h -4 v -5"
+       stroke-linecap="butt"
+       id="path3437" />
+    <path
+       d="m 11,34 3,-3 h 17 l 3,3"
+       id="path3439" />
+    <path
+       d="M 14,31 V 18.5 H 31 V 31"
+       stroke-linecap="butt"
+       stroke-linejoin="miter"
+       id="path3441" />
+    <path
+       d="M 14,18.5 12.5,16 h 20 L 31,18.5"
+       id="path3443" />
+    <path
+       d="M 34,34 H 11"
+       fill="none"
+       stroke-linejoin="miter"
+       id="path3445" />
+  </g>
+  <path
+     d="m 22.5,29.927084 c 0.93471,0 1.691783,-0.757073 1.691783,-1.691782 0,-0.376422 -0.122654,-0.723238 -0.329898,-1.006611 0.824744,-0.473698 1.387261,-1.357655 1.387261,-2.376953 0,-0.85858 -0.397569,-1.62411 -1.019299,-2.127417 1.268837,-0.448321 3.134027,-2.347346 3.134027,-5.697075 h -9.727747 c 0,3.349729 1.865189,5.248754 3.134025,5.697075 -0.621729,0.503307 -1.019298,1.268837 -1.019298,2.127417 0,1.019298 0.562517,1.903255 1.387261,2.376953 -0.207243,0.283373 -0.329897,0.630189 -0.329897,1.006611 0,0.934709 0.757073,1.691782 1.691782,1.691782 z"
+     stroke="#000000"
+     stroke-width="0.634419"
+     stroke-linecap="round"
+     id="path4028"
+     style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+</svg>

--- a/static/images/pieces/chennis/wSB_r.svg
+++ b/static/images/pieces/chennis/wSB_r.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="wSB.svg"
+   id="svg3845"
+   version="1.1"
+   height="45"
+   width="45">
+  <metadata
+     id="metadata3851">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3849">
+    <inkscape:path-effect
+       split_items="false"
+       oposite_fuse="false"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect4448"
+       center_point="-103.61098,72.03113"
+       end_point="-103.61098,147.39645"
+       start_point="-103.61098,-3.3341899"
+       effect="mirror_symmetry" />
+    <inkscape:path-effect
+       effect="mirror_symmetry"
+       start_point="-103.61098,-3.3341899"
+       end_point="-103.61098,147.39645"
+       center_point="-103.61098,72.03113"
+       id="path-effect4256"
+       is_visible="true"
+       lpeversion="1"
+       mode="free"
+       discard_orig_path="false"
+       fuse_paths="true"
+       oposite_fuse="false"
+       split_items="false" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:current-layer="svg3845"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-12"
+     inkscape:window-x="3828"
+     inkscape:cy="-4.0325547"
+     inkscape:cx="28.37444"
+     inkscape:zoom="19.288889"
+     showgrid="false"
+     id="namedview3847"
+     inkscape:window-height="2050"
+     inkscape:window-width="3840"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     inkscape:document-rotation="0" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g2116"
+     transform="matrix(0.83211331,0,0,0.83211331,3.7774503,-0.33748681)">
+    <g
+       fill="#000000"
+       stroke-linecap="butt"
+       id="g2112">
+      <path
+         d="m 35.999995,17.615758 c -3.39,0.97 -10.11,-0.43 -13.5,2 -3.39,-2.43 -10.11,-1.03 -13.4999997,-2 0,0 -1.65,-0.54 -3,-2 0.68,-0.97 1.65,-0.99 3,-0.5 3.3899997,0.97 10.1099997,-0.46 13.4999997,1 3.39,-1.46 10.11,-0.03 13.5,-1 1.354,-0.49 2.323,-0.47 3,0.5 -1.354,1.94 -3,2 -3,2 z"
+         id="path2106"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+      <path
+         d="m 29.999995,21.615758 c -2.5,-2.5 -12.5,-2.5 -15,0 -0.5,1.5 0,2 0,2 0,2.5 2.5,4 2.5,4 -5.5,1.5 -6,11.5 5,15.5 11,-4 10.5,-14 5,-15.5 0,0 2.5,-1.5 2.5,-4 0,0 0.5,-0.5 0,-2 z"
+         id="path2108"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+      <path
+         d="m 19.999995,45.615758 a -2.5,-2.5 0 1 1 5,0 -2.5,-2.5 0 1 1 -5,0 z"
+         id="path2110"
+         style="fill:#d35f5f;fill-opacity:1;stroke:#d35f5f;stroke-opacity:1" />
+    </g>
+    <path
+       d="m 27.499995,27.615758 h -10 m 12.5,-4 h -15"
+       stroke="#ececec"
+       stroke-linejoin="miter"
+       id="path2114"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <path
+     inkscape:path-effect="#path-effect4448"
+     inkscape:original-d="M -99.745078,-1.3007197 C -105.01077,33.87678 -149.43162,66.260788 -162.80489,77.273131 c 23.39443,-1.486303 41.84318,-5.969219 49.87893,-5.905687 -3.78985,50.016626 -46.94654,39.365156 -46.95985,71.818166 33.16237,0 80.332875,-0.35352 115.78722,-0.35352 -0.006,-11.54918 -5.174356,-28.25734 -18.099609,-30.09179 -44.142831,-81.107313 6.642805,-43.090295 -37.546879,-114.0410197 z"
+     transform="matrix(-0.21423887,0,0,-0.21423887,0.30249665,35.040976)"
+     id="path2176-6"
+     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:7.00153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m -103.61098,12.19137 c -12.38926,29.718231 -47.55333,55.496217 -59.19391,65.081761 23.39443,-1.486303 41.84318,-5.969219 49.87893,-5.905687 -3.78985,50.016626 -46.94654,39.365156 -46.95985,71.818166 16.37512,0 36.16578,-0.0862 56.27483,-0.17347 20.10905,0.0873 39.899706,0.17347 56.27483,0.17347 -0.01331,-32.45301 -43.17,-21.80154 -46.95985,-71.818166 8.03575,-0.06353 26.4845,4.419384 49.87893,5.905687 -11.64058,-9.585544 -46.804652,-35.36353 -59.19391,-65.081761 z"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/static/images/pieces/green/bK_r.svg
+++ b/static/images/pieces/green/bK_r.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg16"
+   sodipodi:docname="bK.svg">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs20" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview18" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g14">
+    <path
+       d="m 22.437186,33.995 v 5.63"
+       stroke-linejoin="miter"
+       id="path2" />
+    <path
+       d="m 22.437186,20.625 c 0,0 -4.5,7.5 -3,10.5 0,0 1,2.5 3,2.5 2,0 3,-2.5 3,-2.5 1.5,-3 -3,-10.5 -3,-10.5"
+       fill="#000000"
+       stroke-linecap="butt"
+       stroke-linejoin="miter"
+       id="path4" />
+    <path
+       d="m 33.437186,8.625 c -5.5,-3.5 -15.5,-3.5 -21,0 v 7 c 0,0 -8.9999997,4.5 -5.9999997,10.5 3.9999997,6.5 13.4999997,3.5 15.9999997,-4 v -3.5 3.5 c 3.5,7.5 13,10.5 16,4 3,-6 -5,-10 -5,-10 z"
+       fill="#000000"
+       id="path6" />
+    <path
+       d="m 24.937186,37.625 h -5"
+       stroke-linejoin="miter"
+       id="path8" />
+    <path
+       d="m 12.937186,16.125 c 0,0 -8.4999997,4 -6.0299997,9.65 3.8799997,5.85 13.0299997,1.85 15.5299997,-4.65 l -0.01,-2.1 0.01,2.1 c 2.5,6.5 12.594,10.5 15.503,4.65 2.497,-5.65 -4.853,-9 -4.853,-9"
+       stroke="#ececec"
+       id="path10" />
+    <path
+       d="m 33.437186,15.625 c -5.5,3 -15.5,3 -21,0 m 21,-3.5 c -5.5,3 -15.5,3 -21,0 m 21,-3.5 c -5.5,3 -15.5,3 -21,0"
+       stroke="#ececec"
+       id="path12" />
+  </g>
+</svg>

--- a/static/images/pieces/green/wK_r.svg
+++ b/static/images/pieces/green/wK_r.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45"
+   height="45"
+   version="1.1"
+   id="svg12"
+   sodipodi:docname="wK.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview14" />
+  <g
+     fill="none"
+     fill-rule="evenodd"
+     stroke="#000"
+     stroke-width="1.5"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g10">
+    <path
+       d="m 22.437186,33.995 v 5.63 m 2.5,-2 h -5"
+       stroke-linejoin="miter"
+       id="path2" />
+    <path
+       d="m 22.437186,20.625 c 0,0 -4.5,7.5 -3,10.5 0,0 1,2.5 3,2.5 2,0 3,-2.5 3,-2.5 1.5,-3 -3,-10.5 -3,-10.5"
+       fill="#ffffff"
+       stroke-linecap="butt"
+       stroke-linejoin="miter"
+       id="path4" />
+    <path
+       d="m 33.437186,8.625 c -5.5,-3.5 -15.5,-3.5 -21,0 v 7 c 0,0 -8.9999997,4.5 -5.9999997,10.5 3.9999997,6.5 13.4999997,3.5 15.9999997,-4 v -3.5 3.5 c 3.5,7.5 13,10.5 16,4 3,-6 -5,-10 -5,-10 z"
+       fill="#ffffff"
+       id="path6" />
+    <path
+       d="m 33.437186,15.625 c -5.5,3 -15.5,3 -21,0 m 21,-3.5 c -5.5,3 -15.5,3 -21,0 m 21,-3.5 c -5.5,3 -15.5,3 -21,0"
+       id="path8" />
+  </g>
+</svg>

--- a/static/piece/chennis/chennis2.css
+++ b/static/piece/chennis/chennis2.css
@@ -1,55 +1,55 @@
-.chennis .cg-wrap piece.k-piece.white {
-    background-image: url('../../images/pieces/merida/wK.svg');
+.chennis .cg-wrap piece.k-piece.ally {
+    background-image: url('../../images/pieces/green/wK.svg');
 }
-.chennis .cg-wrap piece.p-piece.white {
-    background-image: url('../../images/pieces/merida/wP.svg');
+.chennis .cg-wrap piece.p-piece.ally {
+    background-image: url('../../images/pieces/chennis/wPR.svg');
 }
-.chennis .cg-wrap piece.pp-piece.white {
-    background-image: url('../../images/pieces/merida/wR.svg');
+.chennis .cg-wrap piece.pp-piece.ally {
+    background-image: url('../../images/pieces/chennis/wRP.svg');
 }
-.chennis .cg-wrap piece.m-piece.white {
-    background-image: url('../../images/pieces/shogun/merida/mono/wC.svg');
+.chennis .cg-wrap piece.m-piece.ally {
+    background-image: url('../../images/pieces/chennis/wMN.svg');
 }
-.chennis .cg-wrap piece.pm-piece.white {
-    background-image: url('../../images/pieces/merida/wN.svg');
+.chennis .cg-wrap piece.pm-piece.ally {
+    background-image: url('../../images/pieces/chennis/wNM.svg');
 }
-.chennis .cg-wrap piece.s-piece.white {
-    background-image: url('../../images/pieces/merida/syno/wS.svg');
+.chennis .cg-wrap piece.s-piece.ally {
+    background-image: url('../../images/pieces/chennis/wSB.svg');
 }
-.chennis .cg-wrap piece.ps-piece.white {
-    background-image: url('../../images/pieces/merida/wB.svg');
+.chennis .cg-wrap piece.ps-piece.ally {
+    background-image: url('../../images/pieces/chennis/wBS.svg');
 }
-.chennis .cg-wrap piece.f-piece.white {
-    background-image: url('../../images/pieces/shogun/merida/blue/wF.svg');
+.chennis .cg-wrap piece.f-piece.ally {
+    background-image: url('../../images/pieces/chennis/wFC.svg');
 }
-.chennis .cg-wrap piece.pf-piece.white {
-    background-image: url('../../images/pieces/merida/shako/wC.svg');
+.chennis .cg-wrap piece.pf-piece.ally {
+    background-image: url('../../images/pieces/chennis/wCF.svg');
 }
 
-.chennis .cg-wrap piece.k-piece.black {
-    background-image: url('../../images/pieces/merida/bK.svg');
+.chennis .cg-wrap piece.k-piece.enemy {
+    background-image: url('../../images/pieces/green/wK_r.svg');
 }
-.chennis .cg-wrap piece.p-piece.black {
-    background-image: url('../../images/pieces/merida/bP.svg');
+.chennis .cg-wrap piece.p-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wPR_r.svg');
 }
-.chennis .cg-wrap piece.pp-piece.black {
-    background-image: url('../../images/pieces/merida/bR.svg');
+.chennis .cg-wrap piece.pp-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wRP_r.svg');
 }
-.chennis .cg-wrap piece.m-piece.black {
-    background-image: url('../../images/pieces/shogun/merida/mono/bC.svg');
+.chennis .cg-wrap piece.m-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wMN_r.svg');
 }
-.chennis .cg-wrap piece.pm-piece.black {
-    background-image: url('../../images/pieces/merida/bN.svg');
+.chennis .cg-wrap piece.pm-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wNM_r.svg');
 }
-.chennis .cg-wrap piece.s-piece.black {
-    background-image: url('../../images/pieces/merida/syno/bS.svg');
+.chennis .cg-wrap piece.s-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wSB_r.svg');
 }
-.chennis .cg-wrap piece.ps-piece.black {
-    background-image: url('../../images/pieces/merida/bB.svg');
+.chennis .cg-wrap piece.ps-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wBS_r.svg');
 }
-.chennis .cg-wrap piece.f-piece.black {
-    background-image: url('../../images/pieces/shogun/merida/blue/bF.svg');
+.chennis .cg-wrap piece.f-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wFC_r.svg');
 }
-.chennis .cg-wrap piece.pf-piece.black {
-    background-image: url('../../images/pieces/merida/shako/bC.svg');
+.chennis .cg-wrap piece.pf-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wCF_r.svg');
 }

--- a/static/piece/chennis/chennis3.css
+++ b/static/piece/chennis/chennis3.css
@@ -1,0 +1,55 @@
+.chennis .cg-wrap piece.k-piece.ally {
+    background-image: url('../../images/pieces/green/wK.svg');
+}
+.chennis .cg-wrap piece.p-piece.ally {
+    background-image: url('../../images/pieces/chennis/wPR.svg');
+}
+.chennis .cg-wrap piece.pp-piece.ally {
+    background-image: url('../../images/pieces/chennis/wRP.svg');
+}
+.chennis .cg-wrap piece.m-piece.ally {
+    background-image: url('../../images/pieces/chennis/wMN.svg');
+}
+.chennis .cg-wrap piece.pm-piece.ally {
+    background-image: url('../../images/pieces/chennis/wNM.svg');
+}
+.chennis .cg-wrap piece.s-piece.ally {
+    background-image: url('../../images/pieces/chennis/wSB.svg');
+}
+.chennis .cg-wrap piece.ps-piece.ally {
+    background-image: url('../../images/pieces/chennis/wBS.svg');
+}
+.chennis .cg-wrap piece.f-piece.ally {
+    background-image: url('../../images/pieces/chennis/wFC.svg');
+}
+.chennis .cg-wrap piece.pf-piece.ally {
+    background-image: url('../../images/pieces/chennis/wCF.svg');
+}
+
+.chennis .cg-wrap piece.k-piece.enemy {
+    background-image: url('../../images/pieces/green/wK_r.svg');
+}
+.chennis .cg-wrap piece.p-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wPR_r.svg');
+}
+.chennis .cg-wrap piece.pp-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wRP_r.svg');
+}
+.chennis .cg-wrap piece.m-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wMN_r.svg');
+}
+.chennis .cg-wrap piece.pm-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wNM_r.svg');
+}
+.chennis .cg-wrap piece.s-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wSB_r.svg');
+}
+.chennis .cg-wrap piece.ps-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wBS_r.svg');
+}
+.chennis .cg-wrap piece.f-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wFC_r.svg');
+}
+.chennis .cg-wrap piece.pf-piece.enemy {
+    background-image: url('../../images/pieces/chennis/wCF_r.svg');
+}

--- a/static/piece/chennis/chennis3.css
+++ b/static/piece/chennis/chennis3.css
@@ -1,55 +1,55 @@
 .chennis .cg-wrap piece.k-piece.ally {
-    background-image: url('../../images/pieces/green/wK.svg');
+    background-image: url('../../images/pieces/green/bK.svg');
 }
 .chennis .cg-wrap piece.p-piece.ally {
-    background-image: url('../../images/pieces/chennis/wPR.svg');
+    background-image: url('../../images/pieces/chennis/bPR.svg');
 }
 .chennis .cg-wrap piece.pp-piece.ally {
-    background-image: url('../../images/pieces/chennis/wRP.svg');
+    background-image: url('../../images/pieces/chennis/bRP.svg');
 }
 .chennis .cg-wrap piece.m-piece.ally {
-    background-image: url('../../images/pieces/chennis/wMN.svg');
+    background-image: url('../../images/pieces/chennis/bMN.svg');
 }
 .chennis .cg-wrap piece.pm-piece.ally {
-    background-image: url('../../images/pieces/chennis/wNM.svg');
+    background-image: url('../../images/pieces/chennis/bNM.svg');
 }
 .chennis .cg-wrap piece.s-piece.ally {
-    background-image: url('../../images/pieces/chennis/wSB.svg');
+    background-image: url('../../images/pieces/chennis/bSB.svg');
 }
 .chennis .cg-wrap piece.ps-piece.ally {
-    background-image: url('../../images/pieces/chennis/wBS.svg');
+    background-image: url('../../images/pieces/chennis/bBS.svg');
 }
 .chennis .cg-wrap piece.f-piece.ally {
-    background-image: url('../../images/pieces/chennis/wFC.svg');
+    background-image: url('../../images/pieces/chennis/bFC.svg');
 }
 .chennis .cg-wrap piece.pf-piece.ally {
-    background-image: url('../../images/pieces/chennis/wCF.svg');
+    background-image: url('../../images/pieces/chennis/bCF.svg');
 }
 
 .chennis .cg-wrap piece.k-piece.enemy {
-    background-image: url('../../images/pieces/green/wK_r.svg');
+    background-image: url('../../images/pieces/green/bK_r.svg');
 }
 .chennis .cg-wrap piece.p-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wPR_r.svg');
+    background-image: url('../../images/pieces/chennis/bPR_r.svg');
 }
 .chennis .cg-wrap piece.pp-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wRP_r.svg');
+    background-image: url('../../images/pieces/chennis/bRP_r.svg');
 }
 .chennis .cg-wrap piece.m-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wMN_r.svg');
+    background-image: url('../../images/pieces/chennis/bMN_r.svg');
 }
 .chennis .cg-wrap piece.pm-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wNM_r.svg');
+    background-image: url('../../images/pieces/chennis/bNM_r.svg');
 }
 .chennis .cg-wrap piece.s-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wSB_r.svg');
+    background-image: url('../../images/pieces/chennis/bSB_r.svg');
 }
 .chennis .cg-wrap piece.ps-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wBS_r.svg');
+    background-image: url('../../images/pieces/chennis/bBS_r.svg');
 }
 .chennis .cg-wrap piece.f-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wFC_r.svg');
+    background-image: url('../../images/pieces/chennis/bFC_r.svg');
 }
 .chennis .cg-wrap piece.pf-piece.enemy {
-    background-image: url('../../images/pieces/chennis/wCF_r.svg');
+    background-image: url('../../images/pieces/chennis/bCF_r.svg');
 }

--- a/static/piece/chennis/chennis4.css
+++ b/static/piece/chennis/chennis4.css
@@ -1,0 +1,55 @@
+.chennis .cg-wrap piece.k-piece.ally {
+    background-image: url('../../images/pieces/green/bK.svg');
+}
+.chennis .cg-wrap piece.p-piece.ally {
+    background-image: url('../../images/pieces/chennis/bPR.svg');
+}
+.chennis .cg-wrap piece.pp-piece.ally {
+    background-image: url('../../images/pieces/chennis/bRP.svg');
+}
+.chennis .cg-wrap piece.m-piece.ally {
+    background-image: url('../../images/pieces/chennis/bMN.svg');
+}
+.chennis .cg-wrap piece.pm-piece.ally {
+    background-image: url('../../images/pieces/chennis/bNM.svg');
+}
+.chennis .cg-wrap piece.s-piece.ally {
+    background-image: url('../../images/pieces/chennis/bSB.svg');
+}
+.chennis .cg-wrap piece.ps-piece.ally {
+    background-image: url('../../images/pieces/chennis/bBS.svg');
+}
+.chennis .cg-wrap piece.f-piece.ally {
+    background-image: url('../../images/pieces/chennis/bFC.svg');
+}
+.chennis .cg-wrap piece.pf-piece.ally {
+    background-image: url('../../images/pieces/chennis/bCF.svg');
+}
+
+.chennis .cg-wrap piece.k-piece.enemy {
+    background-image: url('../../images/pieces/green/bK_r.svg');
+}
+.chennis .cg-wrap piece.p-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bPR_r.svg');
+}
+.chennis .cg-wrap piece.pp-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bRP_r.svg');
+}
+.chennis .cg-wrap piece.m-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bMN_r.svg');
+}
+.chennis .cg-wrap piece.pm-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bNM_r.svg');
+}
+.chennis .cg-wrap piece.s-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bSB_r.svg');
+}
+.chennis .cg-wrap piece.ps-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bBS_r.svg');
+}
+.chennis .cg-wrap piece.f-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bFC_r.svg');
+}
+.chennis .cg-wrap piece.pf-piece.enemy {
+    background-image: url('../../images/pieces/chennis/bCF_r.svg');
+}

--- a/static/piece/chennis/chennis4.css
+++ b/static/piece/chennis/chennis4.css
@@ -1,55 +1,55 @@
-.chennis .cg-wrap piece.k-piece.ally {
-    background-image: url('../../images/pieces/green/bK.svg');
+.chennis .cg-wrap piece.k-piece.white {
+    background-image: url('../../images/pieces/merida/wK.svg');
 }
-.chennis .cg-wrap piece.p-piece.ally {
-    background-image: url('../../images/pieces/chennis/bPR.svg');
+.chennis .cg-wrap piece.p-piece.white {
+    background-image: url('../../images/pieces/merida/wP.svg');
 }
-.chennis .cg-wrap piece.pp-piece.ally {
-    background-image: url('../../images/pieces/chennis/bRP.svg');
+.chennis .cg-wrap piece.pp-piece.white {
+    background-image: url('../../images/pieces/merida/wR.svg');
 }
-.chennis .cg-wrap piece.m-piece.ally {
-    background-image: url('../../images/pieces/chennis/bMN.svg');
+.chennis .cg-wrap piece.m-piece.white {
+    background-image: url('../../images/pieces/shogun/merida/mono/wC.svg');
 }
-.chennis .cg-wrap piece.pm-piece.ally {
-    background-image: url('../../images/pieces/chennis/bNM.svg');
+.chennis .cg-wrap piece.pm-piece.white {
+    background-image: url('../../images/pieces/merida/wN.svg');
 }
-.chennis .cg-wrap piece.s-piece.ally {
-    background-image: url('../../images/pieces/chennis/bSB.svg');
+.chennis .cg-wrap piece.s-piece.white {
+    background-image: url('../../images/pieces/merida/syno/wS.svg');
 }
-.chennis .cg-wrap piece.ps-piece.ally {
-    background-image: url('../../images/pieces/chennis/bBS.svg');
+.chennis .cg-wrap piece.ps-piece.white {
+    background-image: url('../../images/pieces/merida/wB.svg');
 }
-.chennis .cg-wrap piece.f-piece.ally {
-    background-image: url('../../images/pieces/chennis/bFC.svg');
+.chennis .cg-wrap piece.f-piece.white {
+    background-image: url('../../images/pieces/shogun/merida/blue/wF.svg');
 }
-.chennis .cg-wrap piece.pf-piece.ally {
-    background-image: url('../../images/pieces/chennis/bCF.svg');
+.chennis .cg-wrap piece.pf-piece.white {
+    background-image: url('../../images/pieces/merida/shako/wC.svg');
 }
 
-.chennis .cg-wrap piece.k-piece.enemy {
-    background-image: url('../../images/pieces/green/bK_r.svg');
+.chennis .cg-wrap piece.k-piece.black {
+    background-image: url('../../images/pieces/merida/bK.svg');
 }
-.chennis .cg-wrap piece.p-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bPR_r.svg');
+.chennis .cg-wrap piece.p-piece.black {
+    background-image: url('../../images/pieces/merida/bP.svg');
 }
-.chennis .cg-wrap piece.pp-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bRP_r.svg');
+.chennis .cg-wrap piece.pp-piece.black {
+    background-image: url('../../images/pieces/merida/bR.svg');
 }
-.chennis .cg-wrap piece.m-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bMN_r.svg');
+.chennis .cg-wrap piece.m-piece.black {
+    background-image: url('../../images/pieces/shogun/merida/mono/bC.svg');
 }
-.chennis .cg-wrap piece.pm-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bNM_r.svg');
+.chennis .cg-wrap piece.pm-piece.black {
+    background-image: url('../../images/pieces/merida/bN.svg');
 }
-.chennis .cg-wrap piece.s-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bSB_r.svg');
+.chennis .cg-wrap piece.s-piece.black {
+    background-image: url('../../images/pieces/merida/syno/bS.svg');
 }
-.chennis .cg-wrap piece.ps-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bBS_r.svg');
+.chennis .cg-wrap piece.ps-piece.black {
+    background-image: url('../../images/pieces/merida/bB.svg');
 }
-.chennis .cg-wrap piece.f-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bFC_r.svg');
+.chennis .cg-wrap piece.f-piece.black {
+    background-image: url('../../images/pieces/shogun/merida/blue/bF.svg');
 }
-.chennis .cg-wrap piece.pf-piece.enemy {
-    background-image: url('../../images/pieces/chennis/bCF_r.svg');
+.chennis .cg-wrap piece.pf-piece.black {
+    background-image: url('../../images/pieces/merida/shako/bC.svg');
 }

--- a/static/preview.css
+++ b/static/preview.css
@@ -443,9 +443,15 @@ label.piece.piece1.chennis {
     background-image: url('images/pieces/shogun/cburnett/mono/wC.svg');
 }
 label.piece.piece2.chennis {
-    background-image: url('images/pieces/shogun/merida/mono/wC.svg');
+    background-image: url('images/pieces/chennis/wMN_r.svg');
 }
 label.piece.piece3.chennis {
+    background-image: url('images/pieces/chennis/bMN_r.svg');
+}
+label.piece.piece4.chennis {
+    background-image: url('images/pieces/shogun/merida/mono/wC.svg');
+}
+label.piece.piece5.chennis {
     background-image: url('images/pieces/disguised/w.svg');
 }
 


### PR DESCRIPTION
I've included a set of flipped pieces, White and Black, of the standard Chennis two-piece "CBurnett" styled theme. I tested the pieces set locally, and it seemed to work correctly. A preview is attached below. I also swapped the location of the Merida style so it was better grouped.

Having a single color with orientation flipped to show piece ownership is how I made an over-the-board Chennis set, so I thought it would be useful to add them to the site. They are also more clear on the French and US Open courts if you choose the opposite color (otherwise one of promotion colors blends in with the background).

![chennis_flipped_preview](https://github.com/gbtami/pychess-variants/assets/1847787/6e638ea0-574d-4641-9c06-fd61a635903b)
