### PR TITLE
Fixing 2 bugs about variations

### DIFF
--- a/client/analysisCtrl.ts
+++ b/client/analysisCtrl.ts
@@ -912,7 +912,7 @@ export class AnalysisController extends GameController {
         } else {
             // possible new variation move
             if (ffishBoardPly === 1) {
-                if (msg.lastMove === this.steps[this.ply - 1].move) {
+                if (this.ply < this.steps.length && msg.lastMove === this.steps[this.ply].move) {
                     // existing main line played
                     selectMove(this, this.ply);
                     return;


### PR DESCRIPTION
2 bugs in analysis mode:

1. It when scrolling to previous move and then making a move on the board that is the same with the main line, it fails to detect it and starts a new variation instead of scrolling to next existing move - changed this.steps[this.ply - 1] to this.steps[this.ply]
2. Make 2 moves, scroll back once and start a new variation. Make it a long variation - say 10 moves. Scroll back to the 5th move of the variation and make a different move so it tries to erase the rest of the variation after that and append the new move. It will  fails on this same line, because of this.ply too large and outside of mainline steps list so it cannot make this check