### PR TITLE
Fix Issue #987: Add scrollbar to settings dialog

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -866,6 +866,10 @@ ul.guide li {
   top: var(--site-header-height);
   right: 0;
 }
+#settings-lang, #settings-board {
+  overflow-y: auto;
+  max-height: min(100vh - 70px, 91vh);
+}
 #notify-app {
   overflow: hidden;
   width: 25rem;


### PR DESCRIPTION
**Changes**
I added a vertical scrollbar to the language and board settings in a responsive way so the scrollbar doesn't end short on devices with less viewport height. (Issue #987)

https://github.com/gbtami/pychess-variants/assets/126312812/ba7b3ea2-36a1-4afc-a97d-9d30480ecbc4