### PR TITLE
Remove Unnecessary Scrollbar

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -1539,7 +1539,6 @@ table.seeks {
   top: 0;
   width: 100%; /* Full width */
   height: 100%; /* Full height */
-  overflow: auto; /* Enable scroll if needed */
   background-color: rgb(0, 0, 0); /* Fallback color */
   background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
   padding-top: 60px;


### PR DESCRIPTION
The `.modal` scrollbar is not necessary as it just moves the "new game" panel up and down. It persists on viewports with shorter heights. I tested on Safari, Chrome, and Firefox.

https://github.com/gbtami/pychess-variants/assets/126312812/54ce4620-5c38-45cb-9768-2e3ff5b039b4

Removed Scrollbar

https://github.com/gbtami/pychess-variants/assets/126312812/afb14afe-a895-463d-81fe-71c59423f163



