### PR TITLE
Variants Pages Minor Changes

### DIFF
--- a/static/docs/3check960.md
+++ b/static/docs/3check960.md
@@ -6,10 +6,10 @@ This variant can be played by checking the "Chess960" option when creating a Thr
 
 ## 960 Rules
 
-The starting bottom ranks are randomized, but two rules must be followed:
+The starting bottom ranks are randomized, but three rules must be followed:
 
-The bishops must be placed on opposite-color squares.
-The king must be placed on a square between the rooks.
-Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
+* The bishops must be placed on opposite-color squares.
+* The king must be placed on a square between the rooks.
+* Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
 
 All other rules are as in Three-Check.

--- a/static/docs/3check960.md
+++ b/static/docs/3check960.md
@@ -11,6 +11,6 @@ The starting bottom ranks are randomized, but two rules must be followed:
 * The bishops must be placed on opposite-color squares.
 * The king must be placed on a square between the rooks.
 
-* Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
+Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
 
 All other rules are as in Three-Check.

--- a/static/docs/3check960.md
+++ b/static/docs/3check960.md
@@ -6,10 +6,11 @@ This variant can be played by checking the "Chess960" option when creating a Thr
 
 ## 960 Rules
 
-The starting bottom ranks are randomized, but three rules must be followed:
+The starting bottom ranks are randomized, but two rules must be followed:
 
 * The bishops must be placed on opposite-color squares.
 * The king must be placed on a square between the rooks.
+
 * Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
 
 All other rules are as in Three-Check.

--- a/static/docs/atomic960.md
+++ b/static/docs/atomic960.md
@@ -8,8 +8,9 @@ This variant can be played by checking the "Chess960" option when creating an At
 
 The starting bottom ranks are randomized, but two rules must be followed:
 
-The bishops must be placed on opposite-color squares.
-The king must be placed on a square between the rooks.
+* The bishops must be placed on opposite-color squares.
+* The king must be placed on a square between the rooks.
+
 Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
 
 All other rules are as in Atomic.

--- a/static/docs/chess.md
+++ b/static/docs/chess.md
@@ -6,4 +6,4 @@ If you are familiar with chess, then you probably didn't come here to learn the 
 
 If you are not familiar with chess, then the rules are widely available on the internet, such as on Wikipedia or premier chess sites like [lichess.org](https://lichess.org/) and [chess.com](https://www.chess.com/).
 
-As with other variants, you can play chess on Pychess Variants against other people or the AI. You can also set custom positions by adjusting the [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation) and play games with those using standard chess rules.
+As with other variants, you can play chess on Pychess Variants against other people or the AI. You can also [set custom positions](https://www.pychess.org/editor/chess) by adjusting the [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation) and play games with those using standard chess rules.

--- a/static/docs/crazyhouse.md
+++ b/static/docs/crazyhouse.md
@@ -23,8 +23,7 @@ Strategy [as on Lichess](https://lichess.org/variant/crazyhouse)
 
 ## Further Resources 
 
-If you'd like to dive deeper into the world of Crazyhouse and looking for a starting point to study, this article by [@crosky](https://lichess.org/@/crosky) does a great job of introducing 
-typical tactics, strategic concepts and openings: [Crazyhouse, an overview](https://lichess.org/blog/VrQDNSoAACsA8sqc/crazyhouse-an-overview)
+If you'd like to dive deeper into the world of Crazyhouse and looking for a starting point to study, this article by [@crosky](https://lichess.org/@/crosky) does a great job of introducing typical tactics, strategic concepts and openings: [Crazyhouse, an overview](https://lichess.org/blog/VrQDNSoAACsA8sqc/crazyhouse-an-overview)
 
 More Resources: 
 

--- a/static/docs/crazyhouse960.md
+++ b/static/docs/crazyhouse960.md
@@ -8,8 +8,9 @@ This variant can be played by checking the "Chess960" option when creating a Cra
 
 The starting bottom ranks are randomized, but two rules must be followed:
 
-The bishops must be placed on opposite-color squares.
-The king must be placed on a square between the rooks.
+* The bishops must be placed on opposite-color squares.
+* The king must be placed on a square between the rooks.
+
 Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
 
 All other rules are as in Crazyhouse.

--- a/static/docs/es/chess.md
+++ b/static/docs/es/chess.md
@@ -6,4 +6,4 @@ Si conoces el ajedrez, entonces probablemente no has venido aquí para aprender 
 
 Si no conoces el ajedrez, las reglas están fácilmente localizables en Internet, por ejemplo en Wikipedia o sitios de ajedrez como [lichess.org](https://lichess.org/) y [chess.com](https://www.chess.com/).
 
-Al igual que en otras variantes, puedes jugar en Pychess Variants contra otra persona o contra la I.A. Puedes también comenzar en una posición personalizada ajustando el [FEN](https://it.wikipedia.org/wiki/Notazione_Forsyth-Edwards) y jugar partidas usando las reglas estándar de ajedrez.
+Al igual que en otras variantes, puedes jugar en Pychess Variants contra otra persona o contra la I.A. Puedes también [comenzar en una posición personalizada](https://www.pychess.org/editor/chess) ajustando el [FEN](https://it.wikipedia.org/wiki/Notazione_Forsyth-Edwards) y jugar partidas usando las reglas estándar de ajedrez.

--- a/static/docs/es/crazyhouse.md
+++ b/static/docs/es/crazyhouse.md
@@ -24,8 +24,7 @@ Estrategia [tal como está descrita en Lichess (en inglés)](https://lichess.org
 
 ## Recursos Adicionales
 
-Si te interesa introducirte más en el mundo del Crazyhouse y estás buscando un lugar por donde empezar a estudiar, este artículo de [@crosky](https://lichess.org/@/crosky) hace una gran labor introduciendo
-tácticas típicas, conceptos estratégicos y aperturas: [Crazyhouse, an overview (en inglés)](https://lichess.org/blog/VrQDNSoAACsA8sqc/crazyhouse-an-overview)
+Si te interesa introducirte más en el mundo del Crazyhouse y estás buscando un lugar por donde empezar a estudiar, este artículo de [@crosky](https://lichess.org/@/crosky) hace una gran labor introduciendo tácticas típicas, conceptos estratégicos y aperturas: [Crazyhouse, an overview (en inglés)](https://lichess.org/blog/VrQDNSoAACsA8sqc/crazyhouse-an-overview)
 
 Más Recursos: 
 

--- a/static/docs/es/placement.md
+++ b/static/docs/es/placement.md
@@ -2,6 +2,6 @@
 
 Pal Benko  atribuye la idea del "Pre-Ajedrez" o "Shuffle-Chess" a David Bronstein.
 
-A diferencia del "Placement Chess" descrito en el sitio *Chess Variants*, esta variante es simplemente una modificación donde los jugadores por turnos van colocando sus piezas en la primera fila. El enroque solo se puede hacer si el Rey y la Torre correspondiente han sido colocadas en sus casillas normales.
+A diferencia del ["Placement Chess"](https://www.chessvariants.org/play/placement-chess) descrito en el sitio *Chess Variants*, esta variante es simplemente una modificación donde los jugadores por turnos van colocando sus piezas en la primera fila. El enroque solo se puede hacer si el Rey y la Torre correspondiente han sido colocadas en sus casillas normales.
 
-[Haz click aquí para leer más acerca de la historia de esta variante](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess)
+[Más acerca de la historia de esta variante](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess)

--- a/static/docs/fr/placement.md
+++ b/static/docs/fr/placement.md
@@ -4,6 +4,6 @@ Le Placement Chess (ou les échecs Bronstein) est connu sous plusieurs noms, par
 
 Le grand-maître Pal Benko attribuait l'idée de *Pre-Chess* ou *Shuffle-Chess* au grand-maître David Bronstein.
 
-Différente de la version décrite sur le site chessvariants.com, cette variante sur Pychess est une simple modification des échecs occidentaux où les joueurs placent leurs pièces tour à tour sur leur dernière rangée avant de commencer la partie. Le roque n'est légal que si le roi est la tour impliquée sont placés sur leurs cases normales au début de la partie.
+Différente de [la version décrite](https://www.chessvariants.org/play/placement-chess) sur le site chessvariants.com, cette variante sur Pychess est une simple modification des échecs occidentaux où les joueurs placent leurs pièces tour à tour sur leur dernière rangée avant de commencer la partie. Le roque n'est légal que si le roi est la tour impliquée sont placés sur leurs cases normales au début de la partie.
 
 Consulter cet article pour savoir [l'histoire de cette variante](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess).

--- a/static/docs/hu/chess.md
+++ b/static/docs/hu/chess.md
@@ -6,4 +6,4 @@ Ha ismered a sakkot, akkor valószínűleg nem azért jöttél ide, hogy a sakk 
 
 Ha nem ismered a szabályokat, akkor azokat nagyon sok helyen megtalálod az interneten, például a [wikipédián](https://hu.wikipedia.org/wiki/Sakk) vagy a legnagyobb sakkoldalakon, mint pl. a [lichess](https://lichess.org) vagy a [chess.com](https://chess.com).
 
-Ahogyan más variánsokat, úgy sakkot is játszhatsz ezen az oldalon, emberek vagy a számítógép ellen is. Új játszma indításakor lehetőséged van egyedi kezdőpozíciókat is beállítani a [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation) megadásával.
+Ahogyan más variánsokat, úgy sakkot is játszhatsz ezen az oldalon, emberek vagy a számítógép ellen is. Új játszma indításakor lehetőséged van [egyedi kezdőpozíciókat is beállítani](https://www.pychess.org/editor/chess) a [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation) megadásával.

--- a/static/docs/hu/placement.md
+++ b/static/docs/hu/placement.md
@@ -4,4 +4,4 @@ A Pre-Sakk egy sakkvariáns, ami [Benkő Pál](https://hu.wikipedia.org/wiki/Ben
 
 A standard sakktól annyiban tér el, hogy a tisztek kezdőpozícióját a játékosok választhatják meg. Először a világos, aztán a sötét játékos helyez el egy bábut, és így tovább felváltva. A sáncolás csak akkor lehetséges, ha a király és a bástya az eredeti helyére kerül.
 
-A játék ezen az oldalon **Placement Chess** néven elérhető, melynek jelentése "Elhelyezési sakk", ami a bábuk játékosok általi táblára helyezésére utal. Nem összekeverendő a chessvariants oldalán ismertetett [Placement](https://www.chessvariants.com/diffsetup.dir/placement.html)-tel.
+A játék ezen az oldalon **Placement Chess** néven elérhető, melynek jelentése "Elhelyezési sakk", ami a bábuk játékosok általi táblára helyezésére utal. Nem összekeverendő a chessvariants oldalán ismertetett [Placement](https://www.chessvariants.org/play/placement-chess)-tel.

--- a/static/docs/it/chess.md
+++ b/static/docs/it/chess.md
@@ -6,4 +6,4 @@ Se conosci gli scacchi, allora probabilmente non sei venuto qui per impararne le
 
 Se non hai familiarità con gli scacchi, le regole sono facilmente disponibili su internet, come su Wikipedia o sui siti di scacchi più importanti come lichess.org e chess.com.
 
-Come con le altre varianti, puoi giocare a scacchi su Pychess Variants contro altre persone o contro il computer. Puoi anche impostare posizioni personalizzate regolando il [FEN](https://it.wikipedia.org/wiki/Notazione_Forsyth-Edwards) e giocare partite con quelle usando le regole standard degli scacchi.
+Come con le altre varianti, puoi giocare a scacchi su Pychess Variants contro altre persone o contro il computer. Puoi anche [impostare posizioni personalizzate](https://www.pychess.org/editor/chess) regolando il [FEN](https://it.wikipedia.org/wiki/Notazione_Forsyth-Edwards) e giocare partite con quelle usando le regole standard degli scacchi.

--- a/static/docs/it/placement.md
+++ b/static/docs/it/placement.md
@@ -2,6 +2,6 @@
 
 Pal Benko attribuisce l'idea dei "Pre-Scacchi" o "Shuffle-Chess" a David Bronstein.
 
-Diversa dal "Placement Chess" descritta sul sito *Chess Variants*, questa variante è semplicemente una modifica in cui i giocatori posizionano a turno i loro pezzi in prima/ottava traversa. L'arrocco funziona solo quando il re e la torre corrispondente sono nella loro posizione normale.
+Diversa dal ["Placement Chess"](https://www.chessvariants.org/play/placement-chess) descritta sul sito *Chess Variants*, questa variante è semplicemente una modifica in cui i giocatori posizionano a turno i loro pezzi in prima/ottava traversa. L'arrocco funziona solo quando il re e la torre corrispondente sono nella loro posizione normale.
 
-[Clicca qui per saperne di più sulla storia della variante](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess)
+[Saperne di più sulla storia della variante](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess)

--- a/static/docs/kingofthehill960.md
+++ b/static/docs/kingofthehill960.md
@@ -8,8 +8,9 @@ This variant can be played by checking the "Chess960" option when creating a Kin
 
 The starting bottom ranks are randomized, but two rules must be followed:
 
-The bishops must be placed on opposite-color squares.
-The king must be placed on a square between the rooks.
+* The bishops must be placed on opposite-color squares.
+* The king must be placed on a square between the rooks.
+
 Castling is the other major rule to take note of. Basically, regardless of where the rooks are, if you castle, the end position will be the same as if the rooks were in standard position. For example, a queenside castle will result with the king on the c file and the rook on the d file (notation: 0-0-0).
 
 All other rules are as in King of the Hill.

--- a/static/docs/placement.md
+++ b/static/docs/placement.md
@@ -2,6 +2,6 @@
 
 Pal Benko credited the idea of “Pre-Chess” or “Shuffle-Chess” to David Bronstein.
 
-Different than the “Placement Chess” described on the Chess Variants site, this variant is simply a modification where players take turns placing their back rank pieces. Castling only works when the king and the corresponding rook are in their normal position.
+Different than the [“Placement Chess”](https://www.chessvariants.org/play/placement-chess) described on the Chess Variants site, this variant is simply a modification where players take turns placing their back rank pieces. Castling only works when the king and the corresponding rook are in their normal position.
 
-[See here for more about history](https://lichess.org/forum/lichess-feedback/variant-request-pre-chess-aka-shuffle--placement--meta--bronstein--benko-chess)
+[More about history](https://lichess.org/forum/lichess-feedback/variant-request-pre-chess-aka-shuffle--placement--meta--bronstein--benko-chess)

--- a/static/docs/pt/chess.md
+++ b/static/docs/pt/chess.md
@@ -6,4 +6,4 @@ Se conheces as regras do Xadrez, então provavelmente não vieste aqui para apre
 
 Se não conheces o Xadrez, as regras deste estão disponíveis em grande quantidade na Internet, como o Wikipedia ou sites gigantes de Xadrez como o lichess.org e o chess.com.
 
-Assim como todas as variantes, podes jogar Xadrez no Pychess Variants contra outros jogadores ou contra o Computador. Também podes personalizar posições ajustando o  [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation) e jogar partidas a partir destas usando as regras normais de Xadrez.
+Assim como todas as variantes, podes jogar Xadrez no Pychess Variants contra outros jogadores ou contra o Computador. Também podes [personalizar posições](https://www.pychess.org/editor/chess) ajustando o  [FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation) e jogar partidas a partir destas usando as regras normais de Xadrez.

--- a/static/docs/pt/placement.md
+++ b/static/docs/pt/placement.md
@@ -2,6 +2,6 @@
 
 O jogador de Xadrez Pal Benko atribui a ideia de "Pré-Xadrez" ou "Baralho-de-Xadrez" a David Bronstein.
 
-Esta variante é diferente do "Placement Chess" descrita no site de Chess Variants, esta variante é apenas uma modificação onde os jogadores configuram a sua posição inicial na primeira linha. O Roque só resulta quando o Rei e a Torre estão na sua posição normal.
+Esta variante é diferente do ["Placement Chess"](https://www.chessvariants.org/play/placement-chess) descrita no site de Chess Variants, esta variante é apenas uma modificação onde os jogadores configuram a sua posição inicial na primeira linha. O Roque só resulta quando o Rei e a Torre estão na sua posição normal.
 
-[Veja aqui mais detalhes (inglês)](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess)
+[Mais detalhes (inglês)](http://www.quantumgambitz.com/blog/chess/cga/bronstein-chess-pre-chess-shuffle-chess)

--- a/static/docs/zh/chess.md
+++ b/static/docs/zh/chess.md
@@ -6,4 +6,4 @@
 
 如果你還不熟悉西洋棋，你可以在網路上找到許多相關教學，例如維基百科或知名西洋棋網站如[lichess.org](https://lichess.org/)和[chess.com](https://www.chess.com/)。
 
-你可以在Pychess上和其他玩家或AI玩各種西洋棋類變體。你也可以透過[FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)自定棋盤，然後以標準玩法玩你自製的棋。
+你可以在Pychess上和其他玩家或AI玩各種西洋棋類變體。透過[FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)，你也可以[自定棋盤](https://www.pychess.org/editor/chess)，然後以標準玩法玩你自製的棋。

--- a/static/docs/zh_CN/chess.md
+++ b/static/docs/zh_CN/chess.md
@@ -6,4 +6,4 @@
 
 如果您还不熟悉国际象棋，你可以在网上找到许多相关教学，例如维基百科或国际象棋在线游玩的网站如[lichess.org](https://lichess.org/)和[chess.com](https://www.chess.com/)。
 
-在Pychess上，您可以与其他玩家或AI玩包括国际象棋在内的各种棋类变体。你也可以使用[FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)修改布局，然后用国际象棋的规则来玩。
+在Pychess上，您可以与其他玩家或AI玩包括国际象棋在内的各种棋类变体。使用[FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)，你也可以[修改布局](https://www.pychess.org/editor/chess)，然后用国际象棋的规则来玩。

--- a/static/docs/zh_TW/chess.md
+++ b/static/docs/zh_TW/chess.md
@@ -6,4 +6,4 @@
 
 如果你還不熟悉西洋棋，你可以在網路上找到許多相關教學，例如維基百科或知名西洋棋網站如[lichess.org](https://lichess.org/)和[chess.com](https://www.chess.com/)。
 
-你可以在Pychess上和其他玩家或AI玩各種西洋棋類變體。你也可以透過[FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)自定棋盤，然後以標準玩法玩你自製的棋。
+你可以在Pychess上和其他玩家或AI玩各種西洋棋類變體。透過[FEN](https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)，你也可以[自定棋盤](https://www.pychess.org/editor/chess)，然後以標準玩法玩你自製的棋。


### PR DESCRIPTION
**Chess**
* linked Pychess editor in text

**Crazyhouse**
* removed line break

**Placement**
* linked Chess Variants site's version of Placement Chess
* removed "see here, click here, etc" type of unnecessary link text

**English articles for 960 versions of 3check, atomic, crazyhouse, KOTH**
* added bullet points
* separated the two main rules and the castling rule 
(the same articles in other languages already have these changes)

I committed three times for one file because I made a mistake.