### PR TITLE
Align orange lobby tab markers

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -2520,15 +2520,15 @@ span[aria-selected=true], div[role=tablist] span:hover::after {
     transform: scale(1);
 }
 div > span[role=tab]::after {
-    content:'';
-    background:var(--rusty);
-    height:2px;
-    position:absolute;
-    width:96%;
-    left:2%;
-    bottom:-2px;
-    transition:all .25s;
-    transform:scale(0)
+    content: '';
+    background: var(--rusty);
+    height: 2px;
+    position: absolute;
+    width: 100%;
+    left: 0%;
+    bottom: -2px;
+    transition: all .25s;
+    transform: scale(0)
 }
 .indicator {
     color: var(--rusty);


### PR DESCRIPTION
The lobby tab markers are unaligned with the container and they briefly intersect when switching the tabs.

https://github.com/gbtami/pychess-variants/assets/126312812/a32d33d8-37e0-4db0-bf68-5d0d0cd9bd4b

https://github.com/gbtami/pychess-variants/assets/126312812/7045ee1e-aa87-408f-b41b-1d60bf881799

Also spacing