### PR TITLE
Adjust shield icons placement in tournaments page

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -2344,7 +2344,6 @@ a#zen-button {
 }
 .shield-trophy {
   display: block;
-  width: 67px;
   height: 80px;
   background: url(images/trophy/shield-gold.png) no-repeat;
   background-size: contain;


### PR DESCRIPTION
Shield icons are misaligned to the left
<img width="600" alt="Shield icons are misaligned to the left" src="https://github.com/gbtami/pychess-variants/assets/126312812/9510ac35-2d54-40e3-8c34-157301660d62">

Shield icons are centered
<img width="600" alt="Shield icons are centered" src="https://github.com/gbtami/pychess-variants/assets/126312812/5c452dca-5253-4290-9777-142ea972c24d">
