### PR TITLE
Memory page changes

### DIFF
--- a/static/memory.css
+++ b/static/memory.css
@@ -12,9 +12,9 @@ div.memory {
     align-items: center;
 }
 .memory .header h1 {
-    font-size: 7em;
+    font-size: 3em;
     color: #b3b3b3;
-    margin: 0 2rem 0 0;
+    margin: 0 2rem 0;
 }
 .memory .header p {
     padding: 0;
@@ -73,6 +73,8 @@ memory .memory-game {
   transform: scale(1);
   transform-style: preserve-3d;
   transition: transform 0.5s;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .memory-card:active {


### PR DESCRIPTION
* make header smaller
* align header
* prevent accidental highlighting of cards

<img width="600" alt="memory page before" src="https://github.com/gbtami/pychess-variants/assets/126312812/aed213c4-f797-4904-a8c3-0876cdff87ab">
<img width="600" alt="memory page after" src="https://github.com/gbtami/pychess-variants/assets/126312812/0a7d6b29-9096-465c-9b16-9b3469f5bcd8">
