### PR TITLE
Improve counter links

### DIFF
--- a/static/lobby.css
+++ b/static/lobby.css
@@ -30,8 +30,12 @@
   flex: 1;
   display: flex;
   flex-flow: column nowrap;
+  align-items: flex-start;
   position: absolute;
   bottom: 0;
+}
+.lobby-count a {
+  transition: color 150ms;
 }
 @media only screen and (max-width: 799px) {
   .lobby-count {


### PR DESCRIPTION
* fixed player counter link hitbox being wider than intended
* added color transition 

<img width="130" alt="User can click on link even when not on it due to flexbox" src="https://github.com/gbtami/pychess-variants/assets/126312812/02e9ef38-3461-40b1-a449-904ae11f93ce">
<img width="130" alt="Restricted link hitbox" src="https://github.com/gbtami/pychess-variants/assets/126312812/b325ba67-c808-4fc1-940e-86bc610c8e19">
