### PR TITLE
Separate new tournament box shadows from transition animation

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -2323,8 +2323,12 @@ div.ctable-container {
     var(--blue-active),
     var(--blue-passive) 100%
   );
+}
+  
+div#spotlights > div {
   box-shadow: var(--base-shadow);
 }
+  
 .tour-spotlight:hover {
   opacity: 1;
 }


### PR DESCRIPTION
<img width="400" alt="box shadow should not be on hover" src="https://github.com/gbtami/pychess-variants/assets/126312812/31c49e47-2270-4b8a-8634-7127e25026ab">



