### PR TITLE
Allow styling of links in lists on variants pages

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -1084,7 +1084,8 @@ a:hover,
   color: var(--link-hover);
 }
 p a,
-.blogs ul li a {
+.blogs ul li a,
+div.guide li a {
   color: var(--link-hover);
 }
 div a {


### PR DESCRIPTION
<img width="450" alt="zh" src="https://github.com/gbtami/pychess-variants/assets/126312812/e3251dd8-0541-4cbb-9727-033f91a795fb">
<img width="450" alt="zh2" src="https://github.com/gbtami/pychess-variants/assets/126312812/3d67a6c9-424d-4a75-a7ab-6508d69f231d">

* need div.guide to prevent it from affecting sidebar links
