### PR TITLE
Improve tournament join button

### DIFF
--- a/static/tournament.css
+++ b/static/tournament.css
@@ -87,6 +87,7 @@ span.page {
     position: relative;
     background-color: var(--bg-color2);
     box-shadow: var(--base-shadow);
+    height: 40px;
 }
 .btn-controls i {
     font-size: 1.2em;

--- a/static/tournament.css
+++ b/static/tournament.css
@@ -104,10 +104,12 @@ span.page {
     line-height: 1.3;
 }
 button#action {
+    height: auto;
+    margin: 0;
     position: absolute;
     right: 5px;
     top: -3px;
-    padding: 3px 20px;
+    padding: 8px 20px;
     border-radius: 8px;
     border-bottom: 5px solid #759900;
     color: white;
@@ -115,6 +117,7 @@ button#action {
     font-size:1.2em;
     text-shadow: 0 -1px #759900;
     transform: translate(0px, 0px);
+    transition: 0.2s all;
 }
 button#action::before {
     margin-right: 0.4em;


### PR DESCRIPTION
https://github.com/gbtami/pychess-variants/assets/126312812/ca713769-1c36-4390-bc26-259fd343ec04

https://github.com/gbtami/pychess-variants/assets/126312812/c58408ca-8b3a-45f3-9827-6eb1f8656a37

The problem was that the height of the button was increasing to adjust for the decrease in the bottom border width due to border-box box-sizing.
