### PR TITLE
Reduce padding for links to variants on small screens

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -706,6 +706,9 @@ ul.guide li {
     font-size: 1rem;
     margin: 0;
   }
+  ul.guide li a {
+    padding: 8px 0px;
+  }
 }
 .login.nav-link {
   align-self: center;


### PR DESCRIPTION
Reduce top and bottom padding by 1/3 and remove margin-right that caused "KOTH 960" to take two lines. 

Before
<img width="500" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/1c290d2c-c444-4454-9ad2-1e4ae79fbd04">

After
<img width="500" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/679b21c8-8aa2-43fb-af71-180bc8f398b8">
