### PR TITLE
Prevent variants videos from overflowing

### DIFF
--- a/static/variants.css
+++ b/static/variants.css
@@ -2,6 +2,7 @@
 iframe {
     display: block;
     margin: auto;
+    max-width: 100%;
 }
 .guide p img, .guide table {
     margin-left: auto;


### PR DESCRIPTION
On mobile, videos will take up space on the side so there will be an x-scrollbar.