### PR TITLE
Fix Issue #1223: Puzzle source breaks across multiple lines

### DIFF
--- a/client/puzzleCtrl.ts
+++ b/client/puzzleCtrl.ts
@@ -212,7 +212,7 @@ export class PuzzleController extends AnalysisController {
                     ]),
                     h('div', [
                         h('span', _('Source:')),
-                        h('a', { attrs: { href: sourceLink } }, sourceText.replace(/\.github\.io/, ''),
+                        h('a', { attrs: { href: sourceLink } }, sourceText.replace(/\.github\.io/, '')),
                     ]),
                     h('div', [
                         h('span', _('Type:')),

--- a/client/puzzleCtrl.ts
+++ b/client/puzzleCtrl.ts
@@ -212,7 +212,7 @@ export class PuzzleController extends AnalysisController {
                     ]),
                     h('div', [
                         h('span', _('Source:')),
-                        h('a', { attrs: { href: sourceLink } }, sourceText),
+                        h('a', { attrs: { href: sourceLink } }, sourceText.replace(/\.github\.io/, ''),
                     ]),
                     h('div', [
                         h('span', _('Type:')),


### PR DESCRIPTION
#1223

[Test Puzzle](https://www.pychess.org/puzzle/Kebky)

My PR only addresses the specific case of ".github.io" , but I don't think there are or will be other puzzle sources with long names.