### PR TITLE
Set title for 404 page

### DIFF
--- a/server/index.py
+++ b/server/index.py
@@ -383,8 +383,6 @@ async def index(request):
 
     if view == "lobby":
         page_title = "PyChess • Free Online Chess Variants"
-    elif view is None:
-        page_title = "404 Page Not Found"
     else:
         page_title = "%s • PyChess" % view.capitalize()
 

--- a/server/index.py
+++ b/server/index.py
@@ -383,6 +383,8 @@ async def index(request):
 
     if view == "lobby":
         page_title = "PyChess • Free Online Chess Variants"
+    elif view is None:
+        page_title = "404 Page Not Found"
     else:
         page_title = "%s • PyChess" % view.capitalize()
 

--- a/server/server.py
+++ b/server/server.py
@@ -66,7 +66,7 @@ async def handle_404(request, handler):
             template = app_state.jinja["en"].get_template("404.html")
             text = await template.render_async(
                 {
-                    "title": "404 Page Not Found"
+                    "title": "404 Page Not Found",
                     "dev": DEV,
                     "home": URI,
                     "theme": theme,

--- a/server/server.py
+++ b/server/server.py
@@ -63,6 +63,7 @@ async def handle_404(request, handler):
             if session_user is not None:
                 user = await app_state.users.get(session_user)
                 theme = user.theme
+            view = "404 Page Not Found"
             template = app_state.jinja["en"].get_template("404.html")
             text = await template.render_async(
                 {

--- a/server/server.py
+++ b/server/server.py
@@ -63,7 +63,6 @@ async def handle_404(request, handler):
             if session_user is not None:
                 user = await app_state.users.get(session_user)
                 theme = user.theme
-            view = "404 Page Not Found"
             template = app_state.jinja["en"].get_template("404.html")
             text = await template.render_async(
                 {

--- a/server/server.py
+++ b/server/server.py
@@ -66,6 +66,7 @@ async def handle_404(request, handler):
             template = app_state.jinja["en"].get_template("404.html")
             text = await template.render_async(
                 {
+                    "title": "404 Page Not Found"
                     "dev": DEV,
                     "home": URI,
                     "theme": theme,


### PR DESCRIPTION
Currently, [invalid Pychess links](https://www.pychess.org/fadf) don't have a set `<title>`  so the `<title>` defaults to the page link. I think this happens because the `view` is never defined.

https://github.com/gbtami/pychess-variants/blob/f8a2527f003c78508d20844f55e87fca59bb2e35/server/index.py#L384-L387



