### PR TITLE
Make border color separating game requests stronger

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -1541,7 +1541,7 @@ table.seeks {
 }
 .seeks tbody tr {
   cursor: pointer;
-  border-bottom: 1px solid var(--bg-color2);
+  border-bottom: 1px solid var(--chat-entry-border-top);
   z-index: 1;
 }
 .seeks tbody tr:hover {


### PR DESCRIPTION
<img width="600" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/6197c351-1c25-40d5-8ee8-8761dbce2939">

<img width="600" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/83ee352d-c97a-4246-8c9b-35c1bcf0eb3c">

Currently the bottom-borders are almost impossible to see.