### PR TITLE
Remove self link from profile

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -23,7 +23,7 @@
     <div class="player-sum box">
         <div class="player-head">
             <h1 class="player">
-                <a class="user-link" href="/@/{{ profile }}"><player-title>{{ profile_title }}</player-title> {{ profile }}</a>
+                <player-title>{{ profile_title }}</player-title> {{ profile }}
             </h1>
             <div class="trophies">
             {% for key, kind in trophies %}


### PR DESCRIPTION
It doesn't make sense for there to be a link to someone's profile when the user is already on that page.