### PR TITLE
Remove variant name from tournament description

### DIFF
--- a/client/lobby.ts
+++ b/client/lobby.ts
@@ -748,7 +748,6 @@ export class LobbyController implements ChatController {
     private spotlightView(spotlight: Spotlight) {
         const variant = VARIANTS[spotlight.variant];
         const chess960 = spotlight.chess960;
-        const variantName = variant.displayName(chess960);
         const dataIcon = variant.icon(chess960);
         const lang = languageSettings.value;
         const name = spotlight.names[lang] ?? spotlight.names['en'];

--- a/client/lobby.ts
+++ b/client/lobby.ts
@@ -758,7 +758,6 @@ export class LobbyController implements ChatController {
             h('span.content', [
                 h('span.name', name),
                 h('span.more', [
-                    h('variant', variantName + ' • '),
                     h('nb', ngettext('%1 player', '%1 players', spotlight.nbPlayers) + ' • '),
                     h('info-date', { attrs: { "timestamp": spotlight.startsAt } } )
                 ])


### PR DESCRIPTION
Proposed Pychess upcoming tournament
<img width="400" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/e8578ba1-76ed-4416-ba32-55cd3e58bd92">

Lichess upcoming tournament
<img width="400" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/b895777a-3052-4414-afc2-431bf430d280">
