### PR TITLE
Increase visibility of faq questions in dark mode

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -106,7 +106,7 @@
   --notify-new: #465330;
   --gold: #bf811d;
   --rusty: #d64f00;
-  --ct-current: #a1420a;
+  --ct-current: #f16e22;
   --clock-hurry-bg: #502826;
   --clock-overtime-bg: #474722;
   --clock-running-bg: #384722;


### PR DESCRIPTION
Before
<img width="300" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/3691b602-fb51-4ee1-b395-b814e912aabf">

After
<img width="300" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/9f4d3915-e7a9-4998-a695-45b2dde08b66">

This is the only thing `--ct-current `is responsible for.