### PR TITLE
Limit blog preview rows

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -622,6 +622,7 @@ posts {
   grid-template-rows: auto;
   font-size: 0.9em;
   line-height: 1.5;
+  grid-auto-rows: 0;
 }
 a.post {
   background-color: var(--bg-color0);


### PR DESCRIPTION

https://github.com/gbtami/pychess-variants/assets/126312812/49ef741c-e3a4-4276-94f9-8c2512d95250

Right now the blog preview is forming rows of 2 and 1 or 3 rows of 1 depending on the viewport.