### PR TITLE
Refactor stats ui

### DIFF
--- a/static/stats.css
+++ b/static/stats.css
@@ -13,3 +13,19 @@
 .highcharts-legend-item:hover text {
     fill: var(--link-hover) !important;
 }
+.highcharts-axis-labels text {
+    fill: var(--font-color) !important;
+}
+.highcharts-axis-title {
+  fill: var(--font-color) !important;
+  font-size: 1em !important;
+}
+.highcharts-legend-navigation {
+  fill: var(--font-color);
+}
+#linear {
+    margin-left: 60px;
+}   
+#stats label {
+    padding-right: 30px;
+}


### PR DESCRIPTION
*makes title, dates, y-axis labels, variant list page count easy to see in dark mode
*moves checkbox inputs to the right

Light before

<img width="900" alt="lightstats1" src="https://github.com/gbtami/pychess-variants/assets/126312812/614703ad-74f7-4d0e-87a3-291351a9c330">

Light after

<img width="900" alt="lightstats2" src="https://github.com/gbtami/pychess-variants/assets/126312812/fa5c8b41-54d1-4b77-96d8-802ee3480f2b">

Dark before

<img width="900" alt="darkstats1" src="https://github.com/gbtami/pychess-variants/assets/126312812/eec8b706-a61b-43c7-b9be-656693c10076">

Dark after
<img width="900" alt="darkstats2" src="https://github.com/gbtami/pychess-variants/assets/126312812/150f4523-0d24-4f50-ae21-96347f1be383">
