### PR TITLE
Improve blog preview 

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -631,6 +631,7 @@ a.post {
   align-items: center;
   position: relative;
   box-shadow: var(--base-shadow);
+  border-radius: 5px;
 }
 a.post:hover {
   color: var(--font-color);
@@ -641,7 +642,6 @@ a.post img {
   max-width: none;
   width: 100%;
   height: auto;
-  border-radius: 3px;
   object-fit: cover;
   aspect-ratio: 1.5;
 }
@@ -650,9 +650,12 @@ a.post span.text {
   flex-direction: column;
   max-height: 12em;
   padding: 3% 3% 4% 6%;
+  margin: 0;
 }
 a.post span.text strong {
   font-size: 1.2em;
+  margin-bottom: 10px;
+  color: var(--font-color);
 }
 a.post time {
   font-size: 90%;

--- a/static/site.css
+++ b/static/site.css
@@ -634,7 +634,7 @@ a.post {
   border-radius: 5px;
 }
 a.post:hover {
-  color: var(--font-color);
+  color: var(--link-color);
   background: var(--post-hover);
   box-shadow: none;
 }


### PR DESCRIPTION
* moves border-radius from image to entire post card
* resets margin-right of post text that caused it to wrap early
* sets title and subtitle apart in distance and color

Light before
<img width="600" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/7701a02c-d177-47a7-96d1-2a975625e0c2">

Light after
<img width="600" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/b7898b6a-75a6-428b-aa17-43bfe657d99c">

Dark before
<img width="600" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/aacf60e6-3bf2-477e-8227-60f804c7e17f">

Dark after
<img width="600" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/c6f8b925-e8fb-4578-8a29-2fe18a0c9a35">
