### PR TITLE
Add spotlight border radius and sidebar shadows

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -467,7 +467,6 @@ span[role=tab], div.seeks-table thead {
   display: flex;
   flex-flow: column nowrap;
   justify-content: right;
-  overflow: hidden;
 }
 .sidebar-second {
   grid-area: table;
@@ -2390,6 +2389,8 @@ div.ctable-container {
 }
   
 div#spotlights > div {
+  border-radius: 7px;
+  overflow: hidden;
   box-shadow: var(--base-shadow);
 }
   

--- a/static/videos.css
+++ b/static/videos.css
@@ -16,7 +16,7 @@
   overflow: hidden;
   transition: all 150ms;
   color: #4d4d4d;
-  border-radius: 3px;
+  border-radius: 5px;
   box-shadow: var(--base-shadow);
 }
 figure {


### PR DESCRIPTION
Comparison:

<img width="350" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/36a72a44-8716-4246-8e43-22e21fe4ff49">

<img width="350" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/fd96501b-b8f0-43a4-bbb3-4beeff97b203">
