### PR TITLE
Fix light mode winners contrast

### DIFF
--- a/static/players.css
+++ b/static/players.css
@@ -61,6 +61,9 @@ td rating {
 .card div.info0 a {
     color: WhiteSmoke;
 }
+.winners .card div.info0 a {
+    color: var(--clock-running-color);
+}
 div.info0.icon::before {
     opacity: 0.9;
 }


### PR DESCRIPTION
Before
<img width="500" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/65f3dd30-15fd-4268-8c2f-82fad743ee89">

After
<img width="500" alt="" src="https://github.com/gbtami/pychess-variants/assets/126312812/a71e5fe0-ee3f-46c6-9697-da3b67d8b834">

For dark mode it doesn't really change.

I'm planning on simplifying stylesheets later as styling elements is getting really messy.