### PR TITLE
add chaturanga as alternate start FEN

### DIFF
--- a/client/variants.ts
+++ b/client/variants.ts
@@ -752,6 +752,10 @@ export const VARIANTS: Record<string, Variant> = {
         boardFamily: "makruk8x8", pieceFamily: "shatranj",
         pieceRow: ["k", "q", "r", "b", "n", "p"],
         promotion: { type: "regular", order: ["q"] },
+        alternateStart: {
+            '': "",
+            'Chaturanga': "rnbkqbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1",
+        },
     }),
 
     capablanca: variant({


### PR DESCRIPTION
for convenience in playing the original variant that spawned chess
in chaturanga the kings do not face each other, the white king on the e-file and the black king on the d-file