### PR TITLE
Fix dialog bugs on smaller viewport widths

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -377,8 +377,7 @@ iframe {
     );
   }
   .modal {
-    width: 100%;
-    height: 100%;
+      width: min(400px, 80vw);
   }
 }
 @media (max-width: 599px) {
@@ -1718,7 +1717,6 @@ input {
 .modal-content {
   display: flex;
   flex-flow: column;
-  max-height: 100%;
   background-color: var(--modal-bg);
   margin: 0 auto;
   max-width: min(calc(60vw + 100px), 450px);


### PR DESCRIPTION
When the dialog is opened on viewports smaller than 800px
<img width="250" alt="" src="https://github.com/user-attachments/assets/b443ba88-b1ad-46cb-a4b3-272e6de5e6a9" />

What the dialog looks like on larger viewports, specifically on Safari (seriously)
<img width="300" alt="" src="https://github.com/user-attachments/assets/43d55a07-3577-4b9d-9aff-50d2bf03748c" />

If you dont have Safari there are emulators that allow you to see it

Result
<img width="200" alt="" src="https://github.com/user-attachments/assets/4dde0567-6d56-4814-8f16-d4fac1bfdd77" />
