### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Python-CI
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/26](https://github.com/gbtami/pychess-variants/security/code-scanning/26)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves checking out code, setting up Python, caching dependencies, linting, and running tests, it only requires read access to the repository contents. 

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that the `GITHUB_TOKEN` has limited access throughout the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
