### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,9 @@ name: Nodejs-CI
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/29](https://github.com/gbtami/pychess-variants/security/code-scanning/29)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting them to `contents: read`. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, which is sufficient for the operations performed in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
