### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -250,7 +250,7 @@ function start() {
     searchInput.addEventListener("keyup", function(e) {
         showResults(searchInput.value);
         if (e.keyCode === 13) {
-            window.location.href = `${model["home"]}/@/${searchInput.value}`;
+            window.location.href = `${model["home"]}/@/${encodeURIComponent(searchInput.value)}`;
         }
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/18](https://github.com/gbtami/pychess-variants/security/code-scanning/18)

To fix the issue, we need to sanitize or escape the untrusted data before using it in the URL. The best approach is to use a library or built-in function to encode the data as a URL component, ensuring that any special characters are properly escaped. This prevents malicious input from being interpreted as executable code.

Specifically:
1. Use `encodeURIComponent` to sanitize `searchInput.value` before concatenating it into the URL.
2. Ensure that `model["home"]` is a trusted value or sanitize it as well.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
