### PR TITLE
Fix: Arrows missing from duck chess analysis suggestions

### DIFF
--- a/client/analysisCtrl.ts
+++ b/client/analysisCtrl.ts
@@ -606,15 +606,15 @@ export class AnalysisController extends GameController {
             this.autoShapes[pv_idx] = [{ orig: o, dest: d, brush: 'paleGreen', piece: undefined, modifiers: { lineWidth: 14 - pv_idx * 2.5 } }];
 
             // duck
-            if (this.variant.rules.duck && pv_move.includes(',')) {
-                this.autoShapes[pv_idx].push({
+            if (this.variant.rules.duck) {
+                this.autoShapes[pv_idx] = [{
                     orig: pv_move.slice(-2) as cg.Key,
                     brush: 'paleGreen',
                     piece: {
                         color: turnColor,
                         role: '_-piece'
                     }
-                })
+                }]
             }
 
             // TODO: gating, promotion

--- a/client/analysisCtrl.ts
+++ b/client/analysisCtrl.ts
@@ -606,15 +606,15 @@ export class AnalysisController extends GameController {
             this.autoShapes[pv_idx] = [{ orig: o, dest: d, brush: 'paleGreen', piece: undefined, modifiers: { lineWidth: 14 - pv_idx * 2.5 } }];
 
             // duck
-            if (this.variant.rules.duck) {
-                this.autoShapes[pv_idx] = [{
+            if (this.variant.rules.duck && pv_move.includes(',')) {
+                this.autoShapes[pv_idx].push({
                     orig: pv_move.slice(-2) as cg.Key,
                     brush: 'paleGreen',
                     piece: {
                         color: turnColor,
                         role: '_-piece'
                     }
-                }]
+                })
             }
 
             // TODO: gating, promotion


### PR DESCRIPTION
In Duck Chess, the analysis board was not showing the arrow for the duck's move, only for the piece's move. This was because the code that generates the shapes for the analysis board was overwriting the arrow shape with the duck's shape.

This commit fixes the issue by appending the duck's shape to the array of shapes, instead of overwriting it. It also adds a check to ensure that the move string contains a duck move before attempting to draw the shape.