### PR TITLE
The regular expression for parsing the engine's "info" string was too…

### DIFF
--- a/client/analysisCtrl.ts
+++ b/client/analysisCtrl.ts
@@ -34,9 +34,9 @@ import { setPocketRowCssVars } from './pocketRow';
 import { updatePoint } from './info';
 
 const EVAL_REGEX = new RegExp(''
-  + /^info depth (\d+) seldepth \d+ multipv (\d+) /.source
+  + /^info depth (\d+)(?: seldepth \d+)? multipv (\d+) /.source
   + /score (cp|mate) ([-\d]+) /.source
-  + /(?:(upper|lower)bound )?nodes (\d+) nps \S+ /.source
+  + /(?:(upper|lower)bound )?nodes (\d+)(?: nps \S+)? /.source
   + /(?:hashfull \d+ )?(?:tbhits \d+ )?time (\S+) /.source
   + /pv (.+)/.source);
 


### PR DESCRIPTION
… strict and would fail to match if optional fields like "seldepth" or "nps" were missing. This would cause the UI to not display the evaluation, including mate scores.

This change makes the "seldepth" and "nps" fields optional in the regex, making the parsing more robust and fixing the bug where check counters were not shown during WASM analysis.