### PR TITLE
Fix: User's own correspondence seeks are now visible

### DIFF
--- a/server/user.py
+++ b/server/user.py
@@ -443,7 +443,7 @@ class User:
         """Seek is compatible when my rating is inside the seek rating range
         and the users are not blocked by any direction"""
 
-        if seek.target not in ("", self.username, seek.creator.username):
+        if self.username != seek.creator.username and seek.target not in ("", self.username):
             return False
 
         self_rating = self.get_rating_value(seek.variant, seek.chess960)


### PR DESCRIPTION
A previous change to fix a privacy issue with invite-only games inadvertently made a user's own correspondence seeks invisible to them. This prevented them from deleting old seeks, and therefore creating new ones once they reached the limit.

This commit modifies the `compatible_with_seek` function in `server/user.py` to ensure that a user can always see their own seeks, regardless of the seek's target. This fixes the bug while preserving the privacy of targeted seeks.