### PR TITLE
Potential fix for code scanning alert no. 38: Clear-text logging of sensitive information

### DIFF
--- a/server/login.py
+++ b/server/login.py
@@ -335,7 +335,7 @@ async def confirm_username(request):
         session.pop("oauth_username", None)
         session.pop("oauth_title", None)
 
-        log.info("Created new user %s from %s OAuth", username, oauth_provider)
+        log.info("Created new user %s via OAuth signup", username)
         return web.json_response({"success": True})
 
     except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/38](https://github.com/gbtami/pychess-variants/security/code-scanning/38)

To fix this problem, we should prevent logging sensitive or potentially user-identifiable information in clear-text logs. Instead of logging the full `oauth_provider` (which may be sensitive or user-derived, according to static analysis and secure defaults), we can either avoid logging it entirely or sanitize the log output. If the information is needed for debugging/auditing, log only non-sensitive details, such as confirming user creation without specifying the provider, or use a constant placeholder if it's truly needed.

- Change the log line at line 338 in `server/login.py` to avoid including `oauth_provider`.  
- The best fix: log only the username, omitting the OAuth provider.  
- No new imports or methods required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
