### PR TITLE
Potential fix for code scanning alert no. 36: Clear-text logging of sensitive information

### DIFF
--- a/server/login.py
+++ b/server/login.py
@@ -58,7 +58,7 @@ async def oauth(request):
     else:
         state = request.rel_url.query.get("state")
         if state != client_secret:
-            log.error("State got back from %s changed", oauth_authorize_url)
+            log.error("OAuth state value mismatch for provider '%s'", provider)
             return web.HTTPFound("/")
 
         if "oauth_code_verifier" not in session:


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/36](https://github.com/gbtami/pychess-variants/security/code-scanning/36)

To fix this problem, it is best not to log the entire `oauth_authorize_url` when an OAuth state mismatch occurs. The logging statement should be edited to either:
- Remove the URL entirely and log only a generic error message (preferred).
- If context is needed for debugging, log only a sanitized identifier, such as the provider name (e.g. `"State mismatch in OAuth callback for %s provider"`).

Specifically, in server/login.py, line 61:
- Change the logging statement so it does *not* output the value of `oauth_authorize_url`.
- No new imports or function definitions are required; only a change to the message being logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
