### PR TITLE
Potential fix for code scanning alert no. 35: Clear-text logging of sensitive information

### DIFF
--- a/server/fishnet.py
+++ b/server/fishnet.py
@@ -256,7 +256,7 @@ async def fishnet_abort(request):
     try:
         app_state.workers.remove(data["fishnet"]["apikey"])
     except KeyError:
-        log.debug("Worker %s was already removed", key)
+        log.debug("Worker %s was already removed", worker)
 
     # re-schedule the job
     app_state.fishnet_queue.put_nowait((ANALYSIS, work_id))


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/35](https://github.com/gbtami/pychess-variants/security/code-scanning/35)

To fix this, we need to remove or redact the API key (`key`) from the log message. Instead of logging the API key, we can log a less sensitive identifier such as the worker’s name (available from the `worker` variable assigned from `FISHNET_KEYS[key]`), or just a generic message without the key. This change should be made directly at line 259 in server/fishnet.py. No additional imports are needed, since we’re not introducing new functionality, just changing the logging argument to use a non-sensitive value already present in scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
