### PR TITLE
Potential fix for code scanning alert no. 37: Clear-text logging of sensitive information

### DIFF
--- a/server/login.py
+++ b/server/login.py
@@ -90,8 +90,7 @@ async def oauth(request):
                     return web.HTTPFound("/login/%s" % provider)
                 else:
                     log.error(
-                        "Failed to get OAuth token from %s",
-                        oauth_token_url,
+                        "Failed to get OAuth token for provider '%s'", provider
                     )
                     return web.HTTPFound("/")
 


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/37](https://github.com/gbtami/pychess-variants/security/code-scanning/37)

To address this issue, the logging statement in the `else` clause at line 92 should be modified so that it does not include the `oauth_token_url` variable in the log message. Instead, a generic error message or one that includes the provider name can be used. This avoids inadvertently logging a value that may, in some configurations, be misconfigured to include sensitive information or could be leveraged by attackers with access to the logs. Only the log line at line 94 needs to be changed; no additional imports or function definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
