### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -1,4 +1,6 @@
 name: Web App Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/40](https://github.com/gbtami/pychess-variants/security/code-scanning/40)

To fix this problem, the workflow should have an explicit `permissions` block specified, ideally at the workflow (top) level, so that all jobs inherit the most restrictive permissions required. In the case of this workflow, the CI job does not require any write access; it is only reading code and performing tests. Thus, the minimal required permission is `contents: read`. The fix is to add a `permissions:` block with `contents: read` after the `name:` block and before or after the `on:` block (placing it just after `name:` is common and clear). No code or step changes are necessary; only the addition of this `permissions:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
