### PR TITLE
Potential fix for code scanning alert no. 30: DOM text reinterpreted as HTML

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -31,6 +31,17 @@ import { devVariants, variantGroups, VARIANTS } from './variants';
 import { variantsIni } from './variantsIni';
 import { showUsernameDialog } from './usernameDialog';
 
+// Utility function to validate and sanitize URLs
+function sanitizeURL(url: string | null): string {
+    try {
+        const parsedURL = new URL(url ?? "", window.location.origin);
+        return parsedURL.href;
+    } catch {
+        console.warn("Invalid URL detected, using default safe value.");
+        return window.location.origin; // Default safe value
+    }
+}
+
 // redirect to correct URL except Heroku preview/dev apps
 if (window.location.href.includes('heroku') && !window.location.href.includes('-pr-') && !window.location.href.includes('-dev-')) {
     window.location.assign('https://www.pychess.org/');
@@ -54,7 +65,7 @@ function initModel(el: HTMLElement) {
     if (board) board = JSON.parse(board);
     return {
         ffish : {} as FairyStockfish,
-        home : el.getAttribute("data-home") ?? "",
+        home : sanitizeURL(el.getAttribute("data-home")) ?? "",
         anon : el.getAttribute("data-anon") ?? "",
         profileid : el.getAttribute("data-profile") ?? "",
         title : el.getAttribute("data-title") ?? "",


### PR DESCRIPTION
Potential fix for [https://github.com/gbtami/pychess-variants/security/code-scanning/30](https://github.com/gbtami/pychess-variants/security/code-scanning/30)

To fix the issue, we need to ensure that the `data-home` attribute value is sanitized or validated before being used. A simple and effective approach is to validate the `data-home` value against a whitelist of allowed URLs or ensure it conforms to a safe format (e.g., a valid URL). If the value is invalid, we can either reject it or replace it with a default safe value.

The fix involves:
1. Adding a validation function to check if the `data-home` value is a valid URL.
2. Sanitizing or replacing the `data-home` value in the `initModel` function before assigning it to `model["home"]`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
