### PR TITLE
Create COPYING.md to credit assets

### DIFF
--- a/static/COPYING.md
+++ b/static/COPYING.md
@@ -1,0 +1,88 @@
+# Pychess Variants Credits and Attribution
+
+Any file in this project that does not state otherwise and is not listed as an
+exception below is part of pychess-variants and copyright (c) 2012-2024 the pychess-variants authors.
+
+For a list of the authors see the commit log or
+https://github.com/gbtami/pychess-variants/graphs/contributors.
+
+Pychess-variants is free software; you can redistribute and/or modify it under the terms
+of the GNU Affero General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+Pychess-variants is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+details.
+
+See the LICENSE file in the root directory for a copy of the _GNU Affero General Public License_.
+
+## Exceptions
+
+Files | Author(s) | License | Notes
+--- | --- | --- | ---
+static/images/pieces/alfaerie/* | David L. Brown | Freeware | From [The Chess Variant Pages](https://www.chessvariants.com/graphics.dir/alfaerie/index.html)
+static/images/pieces/alpha/* | Eric Bentzen | "free for personal non commercial use" | From [enpassant.dk](http://www.enpassant.dk/chess/fonteng.htm)
+static/images/pieces/ataxx/* | pychess-variants contributors | AGPLv3+ | cat.svg and dog.svg license unknown
+static/images/pieces/atopdown/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/chak/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/chennis/* | Couch Tomato | Unknown |
+static/images/pieces/disguised/* | danegraphics | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) | From lichess
+static/images/pieces/dubrovny/* | sadsnake1 | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) | From lichess
+static/images/pieces/empire/* | The House of Staunton | Commercial | Appears to be a commercial design. Not licensed for free use.
+static/images/pieces/firi/* | [James Faure](https://github.com/jfaure/Firi-pieceset) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
+static/images/pieces/green/* | Uray M. János | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.en) | From [Green Chess](https://greenchess.net/info.php?item=downloads)
+static/images/pieces/hoppel/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/janggi/* | [Kadagaden](https://github.com/Kadagaden/chess-pieces) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+static/images/pieces/kaneo/* | [Kadagaden](https://github.com/Kadagaden/chess-pieces) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | Inspired by the Neo pieces of chess.com
+static/images/pieces/kyoto/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/luffy/* | [LuffyKudo](https://github.com/LuffyKudo) | [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/) |
+static/images/pieces/maestro/* | sadsnake1 | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) | From lichess
+static/images/pieces/makruk/* | [Fulmene](https://github.com/Fulmene/makruk-pieces-image) | [CC-BY-SA-4.0](https://creativecommons.org/licenses/by-sa/4.0/) |
+static/images/pieces/mansindam/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/merida/* | Armando Hernandez Marroquin | [GPLv2+](https://www.gnu.org/licenses/gpl-2.0.txt) | From lichess
+static/images/pieces/mono/* | Thibault Duplessis and [Colin M.L. Burnett](https://en.wikipedia.org/wiki/User:Cburnett) | [GPLv2+](https://www.gnu.org/licenses/gpl-2.0.txt) | From lichess
+static/images/pieces/orda/* | Couch Tomato | Unknown |
+static/images/pieces/paradigm/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/santa/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/shinobi/* | Couch Tomato | Unknown |
+static/images/pieces/shogi/* | Various | | See notes
+static/images/pieces/shogun/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/sittuyin/* | [Kadagaden](https://github.com/Kadagaden/chess-pieces) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) |
+static/images/pieces/spartan/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/synochess/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/tori/* | pychess-variants contributors | AGPLv3+ |
+static/images/pieces/xiangqi/* | pychess-variants contributors | AGPLv3+ |
+static/sound/bugchat/* | [rhasspy/piper](https://github.com/rhasspy/piper) | [MIT](https://github.com/rhasspy/piper/blob/master/LICENSE.md) | Generated with `en_GB-northern_english_male-medium` voice. Voice models are under a different license.
+static/sound/futuristic/* | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+ |
+static/sound/lisp/* | [EdinburghCollective](http://lichess.org/@/EdinburghCollective) | [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) |
+static/sound/nes/* | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+ |
+static/sound/piano/* | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+ |
+static/sound/robot/* | pychess-variants contributors | AGPLv3+ |
+static/sound/sfx/* | [Enigmahack](https://github.com/Enigmahack) | AGPLv3+ |
+static/sound/silent/* | pychess-variants contributors | AGPLv3+ |
+static/sound/standard/* | pychess-variants contributors | AGPLv3+ |
+static/images/board/* | pychess-variants contributors | AGPLv3+ |
+static/images/trophy/* | pychess-variants contributors | AGPLv3+ |
+static/images/*Guide/* | pychess-variants contributors | AGPLv3+ |
+static/images/bugroundchat/* | pychess-variants contributors | AGPLv3+ |
+static/images/MidAutumnFestival/* | pychess-variants contributors | AGPLv3+ |
+static/images/SchessEGT/* | pychess-variants contributors | AGPLv3+ |
+static/images/SchessEndings*/* | pychess-variants contributors | AGPLv3+ |
+static/images/SchessRamblings/* | pychess-variants contributors | AGPLv3+ |
+static/images/Santa_hat.svg | [openclipart](https://openclipart.org/detail/190172/santa-hat) | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) |
+static/images/puzzles.jpg | [puzzles.one](https://puzzles.one/) | | From puzzles.one website
+static/images/one-flew-over-the-cuckoos-nest.jpg | | | Movie poster
+static/images/Darth-Vader-Comic.jpg | | | Comic book cover
+static/images/Kuniyoshi_Utagawa_The_actor_17.jpg | [Utagawa Kuniyoshi](https://commons.wikimedia.org/wiki/File:Kuniyoshi_Utagawa_The_actor_Iwai_Kumesabur%C3%B4_II_as_Yaoya_Oshichi.jpg) | Public Domain |
+static/images/pexels-renato-conti-2677849.jpg | [Renato Conti](https://www.pexels.com/photo/a-man-playing-chess-2677849/) | [Pexels License](https://www.pexels.com/license/) |
+static/images/man-design-thinking.453x512.png | | Unknown |
+static/images/spartan-kick.jpg | | | Movie scene
+static/images/zen.png | | Unknown |
+static/images/zen2.png | | Unknown |
+static/images/zh960invitational2022.jpg | | | Tournament banner
+static/images/*.png | pychess-variants contributors | AGPLv3+ | For other png files
+static/images/*.svg | pychess-variants contributors | AGPLv3+ | For other svg files
+static/images/*.jpg | pychess-variants contributors | AGPLv3+ | For other jpg files
+static/images/*.jpeg | pychess-variants contributors | AGPLv3+ | For other jpeg files


### PR DESCRIPTION
Similar to lichess and fairyground, this adds a COPYING.md file to collect all the copyright/credit info about our image and sound files in static/ and create a markdown table with links. This includes detailed research into the origins and licenses of the various piece sets.