### PR TITLE
fix: Users TV bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ tournament*.json
 .env
 yarn-error.log
 .idea/
+*.egg-info/
 server.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,12 @@ black .
 flake8
 
 # Python unit tests
-PYTHONPATH=server python3 -m pytest tests/test_*.py
+PYTHONPATH=server python -m unittest discover -s tests
+
+# Python Playwright tests
+python -m playwright install --with-deps
+PYTHONPATH=server python -m pytest tests/test_e2e.py
+PYTHONPATH=server python -m pytest tests/test_gui.py
 ```
 
 ### Docker Development

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,7 +49,7 @@
                                 data-date="{{ date }}"
                                 data-result="{{ result }}"
                                 data-status="{{ status }}"
-                                data-profile="{{ profile }}"
+                                data-profile="{{ profileid }}"
                                 data-title="{{ profile_title }}"
                                 data-variant="{{ variant }}"
                                 data-chess960="{{ chess960 }}"


### PR DESCRIPTION
Fixes https://github.com/gbtami/pychess-variants/issues/2037

The user's TV redirect was failing because the `profileid` was not being correctly passed from the server to the client. This was due to a typo in the `base.html` template, which was using `profile` instead of `profileid`.

This commit fixes the typo in the template.

I have also added `*.egg-info/` to the `.gitignore` file to prevent build artifacts from being committed in the future.

Finally, I have updated `AGENTS.md` with the correct testing procedures to improve the development workflow.