### PR TITLE
feat: add variantslove.netlify.app to allowed origins

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -43,7 +43,8 @@ TWITCH_CLIENT_SECRET = os.getenv("TWITCH_CLIENT_SECRET", "")
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
 
 ALLOWED_ORIGINS = os.getenv(
-    "ALLOWED_ORIGINS", "https://www.pychess.org,https://cdn.jsdelivr.net,https://variantslove.netlify.app"
+    "ALLOWED_ORIGINS",
+    "https://www.pychess.org,https://cdn.jsdelivr.net,https://variantslove.netlify.app",
 ).split(",")
 
 SOURCE_VERSION = os.getenv("SOURCE_VERSION", "")

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -172,7 +172,7 @@ class GameResultTestCase(AioHTTPTestCase):
         FEN = "3k5/9/9/9/9/5p3/9/5p3/5K3/5C3 w - - 0 1"
         game = Game(get_app_state(self.app), "12345678", "xiangqi", FEN, self.wplayer, self.wplayer)
 
-        for move in ('f2e2', 'f3e3', 'e2f2', 'e3f3', 'f2e2', 'f3e3', 'e2f2', 'e3f3'):
+        for move in ("f2e2", "f3e3", "e2f2", "e3f3", "f2e2", "f3e3", "e2f2", "e3f3"):
             await game.play_move(move, clocks=CLOCKS)
 
         self.assertEqual(game.result, "1-0")
@@ -183,7 +183,7 @@ class GameResultTestCase(AioHTTPTestCase):
         FEN = "3k5/9/9/9/9/5p3/9/5p3/5K3/5C3 w - - 0 1"
         game = Game(get_app_state(self.app), "12345678", "jieqi", FEN, self.wplayer, self.wplayer)
 
-        for move in ('f2e2', 'f3e3', 'e2f2', 'e3f3', 'f2e2', 'f3e3', 'e2f2', 'e3f3'):
+        for move in ("f2e2", "f3e3", "e2f2", "e3f3", "f2e2", "f3e3", "e2f2", "e3f3"):
             await game.play_move(move, clocks=CLOCKS)
 
         self.assertEqual(game.result, "1-0")


### PR DESCRIPTION
This change adds the domain `variantslove.netlify.app` to the list of allowed origins for CORS. This is necessary to allow WebSocket connections for embedded games on that site.