### PR TITLE
feat: Fix memory leak by breaking circular reference

### DIFF
--- a/server/clock.py
+++ b/server/clock.py
@@ -28,6 +28,10 @@ class Clock:
         self.running = False
         return self.secs
 
+    def cleanup(self):
+        self.stop()
+        self.game = None
+
     def restart(self, secs=None):
         self.ply = self.game.ply
         self.color = self.board.color
@@ -139,6 +143,10 @@ class CorrClock:
     def stop(self):
         self.running = False
         return self.mins
+
+    def cleanup(self):
+        self.stop()
+        self.game = None
 
     def restart(self, from_db=False):
         self.ply = self.game.ply

--- a/server/game.py
+++ b/server/game.py
@@ -479,7 +479,7 @@ class Game:
             log.exception("Save IMPORTED game %s ???", self.id)
             return
 
-        self.stopwatch.stop()
+        self.stopwatch.cleanup()
         self.stopwatch.clock_task.cancel()
         try:
             await self.stopwatch.clock_task


### PR DESCRIPTION
A memory leak was identified where asyncio tasks related to finished games were not being garbage collected. This was caused by a circular reference between the `Game` and `Clock` objects.

To resolve this, a `cleanup()` method has been added to the `Clock` and `CorrClock` classes. This method is called at the end of a game's lifecycle to explicitly set the clock's reference to the game object to `None`, thereby breaking the circular reference and allowing the Python garbage collector to reclaim the memory.