### PR TITLE
feat: set samesite cookie attribute to none

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -107,6 +107,7 @@ def make_app(db_client=None, simple_cookie_storage=False, anon_as_test_users=Fal
     app[anon_as_test_users_key] = anon_as_test_users
 
     parts = urlparse(URI)
+    is_secure = parts.scheme == "https"
 
     aiohttp_session.setup(
         app,
@@ -114,7 +115,10 @@ def make_app(db_client=None, simple_cookie_storage=False, anon_as_test_users=Fal
             SimpleCookieStorage()
             if simple_cookie_storage
             else EncryptedCookieStorage(
-                SECRET_KEY, max_age=MAX_AGE, secure=parts.scheme == "https", samesite="Lax"
+                SECRET_KEY,
+                max_age=MAX_AGE,
+                secure=is_secure,
+                samesite="None" if is_secure else "Lax",
             )
         ),
     )


### PR DESCRIPTION
This change sets the `samesite` cookie attribute to `None` to allow for cross-site cookie usage. This is necessary for the variantslove.netlify.app integration to work correctly.

To ensure that local development is not broken, the `samesite` attribute is only set to `None` when the connection is secure (https). For insecure (http) connections, the `samesite` attribute is set to `Lax`.