### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/client/url.ts
+++ b/client/url.ts
@@ -2,6 +2,9 @@
 export function sanitizeURL(url: string | null): string {
     try {
         const parsedURL = new URL(url ?? "", window.location.origin);
+        if (parsedURL.protocol !== "http:" && parsedURL.protocol !== "https:") {
+            throw new Error("Invalid protocol");
+        }
         return parsedURL.href.replace(/\/$/, '');
     } catch {
         console.warn("Invalid URL detected, using default safe value.");

--- a/server/lang.py
+++ b/server/lang.py
@@ -1,4 +1,5 @@
 from contextvars import ContextVar
+from urllib.parse import urlparse
 
 import aiohttp_session
 from aiohttp import web
@@ -21,6 +22,20 @@ async def select_lang(request):
 
     if lang is not None:
         referer = request.headers.get("REFERER")
+        redirect_path = "/"
+        if isinstance(referer, str):
+            parsed_referer = urlparse(referer)
+            if parsed_referer.scheme in ("http", "https") and parsed_referer.netloc == request.host:
+                redirect_path = parsed_referer.path or "/"
+                if parsed_referer.query:
+                    redirect_path = "%s?%s" % (redirect_path, parsed_referer.query)
+            elif (
+                parsed_referer.scheme == ""
+                and parsed_referer.netloc == ""
+                and referer.startswith("/")
+                and not referer.startswith("//")
+            ):
+                redirect_path = referer
         session = await aiohttp_session.get_session(request)
         session_user = session.get("user_name")
         if isinstance(session_user, str) and session_user in app_state.users:
@@ -31,7 +46,7 @@ async def select_lang(request):
                     {"_id": user.username}, {"$set": {"lang": lang}}
                 )
         session["lang"] = lang
-        return web.HTTPFound(referer)
+        return web.HTTPFound(redirect_path)
     else:
         raise web.HTTPNotFound()
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `server/lang.py:L26`

The `select_lang` handler redirects users to the raw `REFERER` header value (`web.HTTPFound(referer)`) without validation. An attacker can supply a crafted Referer value to force redirects to attacker-controlled URLs (phishing, token leakage via redirect chains, etc.).

## Solution

Do not redirect directly to the `REFERER` header. Restrict redirects to same-origin relative paths (e.g., parse and validate host/scheme), or redirect to a fixed safe fallback page when the header is absent/invalid.

## Changes

- `server/lang.py` (modified)
- `client/url.ts` (modified)