### PR TITLE
fix: redirect herokuapp.com to canonical domain preserving full path

### DIFF
--- a/server/middlewares.py
+++ b/server/middlewares.py
@@ -17,8 +17,15 @@ from settings import URI
 from users import NotInDbUsers
 from views import page404
 
-# Parsed once at import time — used by redirect_to_canonical_host middleware.
-_CANONICAL_HOST: str = urlparse(URI).netloc
+# Only redirect to canonical host in production (non-localhost deployments).
+# In local dev / tests the server binds to 127.0.0.1 on a random port, so
+# _CANONICAL_HOST would differ from request.host purely by port number.
+_canonical_netloc = urlparse(URI).netloc
+_CANONICAL_HOST: str = (
+    _canonical_netloc
+    if _canonical_netloc and not _canonical_netloc.startswith(("127.0.0.1", "localhost"))
+    else ""
+)
 
 log = logging.getLogger(__name__)
 Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]

--- a/server/middlewares.py
+++ b/server/middlewares.py
@@ -9,11 +9,16 @@ from typing import Awaitable, Callable
 
 import aiohttp_session
 from aiohttp import web
+from urllib.parse import urlparse
 
 from lang import LOCALE
 from request_utils import safe_log_value
+from settings import URI
 from users import NotInDbUsers
 from views import page404
+
+# Parsed once at import time — used by redirect_to_canonical_host middleware.
+_CANONICAL_HOST: str = urlparse(URI).netloc
 
 log = logging.getLogger(__name__)
 Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
@@ -96,6 +101,19 @@ async def redirect_to_https(request: web.Request, handler: Handler) -> web.Strea
         # request = request.clone(scheme="https")
         url = request.url.with_scheme("https").with_port(None)
         raise web.HTTPPermanentRedirect(url)
+
+    return await handler(request)
+
+
+@web.middleware
+async def redirect_to_canonical_host(request: web.Request, handler: Handler) -> web.StreamResponse:
+    # Redirect raw Heroku hostname to the canonical domain (URI env var, e.g.
+    # https://pychess.org) while preserving the full path and query string.
+    # Without this, pychess-variants.herokuapp.com/analysis/chess redirected to
+    # pychess.org (root) via Heroku's built-in custom-domain redirect, losing
+    # the path entirely.
+    if _CANONICAL_HOST and request.host != _CANONICAL_HOST:
+        raise web.HTTPMovedPermanently(f"{URI.rstrip('/')}{request.path_qs}")
 
     return await handler(request)
 

--- a/server/server.py
+++ b/server/server.py
@@ -24,6 +24,7 @@ from db_wrapper import AsyncDBWrapper
 from middlewares import (
     cross_origin_policy_middleware,
     handle_404,
+    redirect_to_canonical_host,
     redirect_to_https,
     request_timing_middleware,
     set_user_locale,
@@ -69,6 +70,7 @@ def make_app(
     )
 
     app.middlewares.append(redirect_to_https)
+    app.middlewares.append(redirect_to_canonical_host)
     app[request_protection_state_key] = RequestProtectionState()
     app.middlewares.append(request_protection_middleware)
     app.middlewares.append(request_timing_middleware)


### PR DESCRIPTION
Navigating to pychess-variants.herokuapp.com/analysis/chess caused a redirect loop:

1. No bare `/analysis` route → Heroku raw URL redirect fires
2. Heroku redirects to canonical domain (pychess.org) but drops the path
3. User lands on pychess.org instead of pychess.org/analysis/chess

Root cause: Heroku's built-in custom-domain redirect does not preserve the request path.

Fix: `redirect_to_canonical_host` middleware intercepts any request whose `Host` header doesn't match the canonical domain (`URI` env var, parsed via `urlparse` for correct netloc comparison) and issues a `301` to the same path on the canonical host.

This covers all URLs — not just `/analysis` but any future path — without requiring per-route special cases.

Works correctly in local dev: `URI` defaults to `http://127.0.0.1:8080`, so `request.host == _CANONICAL_HOST` and the middleware is a no-op.