### PR TITLE
Faster server restart

### DIFF
--- a/server/bug/utils_bug.py
+++ b/server/bug/utils_bug.py
@@ -34,13 +34,27 @@ async def init_players(app_state: PychessGlobalAppState, wp_a, bp_a, wp_b, bp_b)
 
 
 async def load_game_bug(app_state: PychessGlobalAppState, game_id, *, cache_finished: bool = True):
-    """Return Game object from app cache or from database."""
+    """Return GameBug object from app cache or from database."""
+    if game_id in app_state.games:
+        return app_state.games[game_id]
+
     log.debug("load_game_bug from db ")
     doc = await app_state.db.game.find_one({"_id": game_id})
-
-    log.debug("load_game_bug parse START")
     if doc is None:
         return None
+
+    return await load_game_bug_from_doc(app_state, doc, cache_finished=cache_finished)
+
+
+async def load_game_bug_from_doc(
+    app_state: PychessGlobalAppState, doc, *, cache_finished: bool = True
+):
+    """Return GameBug object from app cache or an already fetched document."""
+    game_id = doc["_id"]
+    if game_id in app_state.games:
+        return app_state.games[game_id]
+
+    log.debug("load_game_bug parse START")
 
     wp, bp, wp_b, bp_b = doc["us"]
     wplayer, bplayer, wplayer_b, bplayer_b = await init_players(app_state, wp, bp, wp_b, bp_b)

--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -23,7 +23,6 @@ from sortedcollections import ValueSortedDict
 
 if TYPE_CHECKING:
     from bug.game_bug import GameBug
-    from clock import CorrClock
     from ws_types import ChatLine, LobbyLeaderboardEntry, TournamentWinnerEntry
     from typing_defs import TournamentCalendarEvent
 
@@ -93,7 +92,7 @@ from typedefs import anon_as_test_users_key, client_key
 from twitch import Twitch
 from user import User
 from users import Users, NotInDbUsers
-from utils import load_game, should_send_game_start_to_bot
+from utils import load_game_from_doc, should_send_game_start_to_bot
 from videos import VIDEOS
 from youtube import Youtube
 from lang import LOCALE
@@ -132,6 +131,7 @@ class PychessGlobalAppState:
 
         self.shutdown = False
         self.tournaments_loaded = asyncio.Event()
+        self.correspondence_games_loaded = asyncio.Event()
 
         self.db_client = app[client_key]
         self.db: Any = app[db_key]
@@ -440,64 +440,106 @@ class PychessGlobalAppState:
                     if game_id is not None:
                         self.invites[game_id] = seek
 
-            # Read games in play and start their clocks
-            cursor = self.db.game.find({"r": "d", "$or": [{"s": -2}, {"s": -1}]})
-            cursor.sort("d", -1)
+            # Read games in play and start their clocks.
+            #
+            # Correspondence games can be numerous and are not latency-critical during
+            # Heroku restart recovery. Load live non-correspondence games before aiohttp
+            # starts accepting traffic, then restore correspondence games in the background.
             today = datetime.now(timezone.utc)
+            active_game_filter = {"r": "d", "$or": [{"s": -2}, {"s": -1}]}
 
-            async for doc in cursor:
-                corr = doc.get("c", False)
+            async def restore_active_game_doc(doc, *, corr: bool) -> bool:
+                game_id = doc["_id"]
+                try:
+                    game = await load_game_from_doc(self, doc)
+                except NotInDbUsers:
+                    log.error("Failed to load game %s", game_id)
+                    return False
 
-                if corr:
-                    # Don't load old never started corr games
-                    if doc["s"] == -2 and doc["d"] < today - timedelta(days=doc["b"]):
-                        continue
-                else:
-                    # Don't load old uninished games
-                    if doc["d"] < today - timedelta(days=1):
-                        continue
+                if game is None:
+                    return False
 
-                if doc["s"] < ABORTED:
-                    game_id = doc["_id"]
+                self.games[game_id] = game
+                if not corr:
                     try:
-                        game = await load_game(self, game_id)
-                        if game is None:
-                            continue
-                        self.games[game_id] = game
-                        if corr:
-                            if TYPE_CHECKING:
-                                assert isinstance(game, Game)
-                            game.wplayer.correspondence_games.append(game)
-                            game.bplayer.correspondence_games.append(game)
-                            if TYPE_CHECKING:
-                                assert isinstance(game.stopwatch, CorrClock)
-                            game.stopwatch.restart(from_db=True)
-                        else:
-                            try:
-                                if TYPE_CHECKING:
-                                    assert isinstance(game, Game)
-                                game.stopwatch.restart()
-                            except AttributeError:
-                                if TYPE_CHECKING:
-                                    assert isinstance(game, GameBug)
-                                game.gameClocks.restart("a")
-                                game.gameClocks.restart("b")
-                    except NotInDbUsers:
-                        log.error("Failed toload game %s", game_id)
-
-                    if game.bot_game:
                         if TYPE_CHECKING:
                             assert isinstance(game, Game)
-                        if len(game.board.move_stack) > 0 and len(game.steps) == 1:
-                            game.create_steps()
-                        bot_player = game.wplayer if game.wplayer.bot else game.bplayer
-                        bot_player.game_queues[game_id] = asyncio.Queue()
-                        if should_send_game_start_to_bot(game):
-                            await bot_player.event_queue.put(game.game_start)
-                        await bot_player.game_queues[game_id].put(game.game_full)
+                        game.stopwatch.restart()
+                    except AttributeError:
+                        if TYPE_CHECKING:
+                            assert isinstance(game, GameBug)
+                        game.gameClocks.restart("a")
+                        game.gameClocks.restart("b")
 
-                    if game.ply > 0:
-                        self.g_cnt[0] += 1
+                if game.bot_game:
+                    if TYPE_CHECKING:
+                        assert isinstance(game, Game)
+                    if len(game.board.move_stack) > 0 and len(game.steps) == 1:
+                        game.create_steps()
+                    bot_player = game.wplayer if game.wplayer.bot else game.bplayer
+                    bot_player.game_queues[game_id] = asyncio.Queue()
+                    if should_send_game_start_to_bot(game):
+                        await bot_player.event_queue.put(game.game_start)
+                    await bot_player.game_queues[game_id].put(game.game_full)
+
+                if game.ply > 0:
+                    self.g_cnt[0] += 1
+                return True
+
+            async def restore_active_games(cursor, *, corr: bool) -> tuple[int, int]:
+                loaded = 0
+                skipped = 0
+                async for doc in cursor:
+                    if corr:
+                        # Don't load old never-started correspondence games.
+                        if doc["s"] == -2 and doc["d"] < today - timedelta(days=doc.get("b", 1)):
+                            skipped += 1
+                            continue
+                    else:
+                        # Don't load old unfinished games.
+                        if doc["d"] < today - timedelta(days=1):
+                            skipped += 1
+                            continue
+
+                    if doc["s"] >= ABORTED:
+                        skipped += 1
+                        continue
+
+                    if await restore_active_game_doc(doc, corr=corr):
+                        loaded += 1
+                    else:
+                        skipped += 1
+                return loaded, skipped
+
+            live_cursor = self.db.game.find(
+                {
+                    **active_game_filter,
+                    "c": {"$ne": True},
+                    "d": {"$gte": today - timedelta(days=1)},
+                }
+            )
+            live_cursor.sort("d", -1)
+            live_loaded, live_skipped = await restore_active_games(live_cursor, corr=False)
+            log.info(
+                "Loaded active live games from db: %s loaded, %s skipped",
+                live_loaded,
+                live_skipped,
+            )
+
+            async def load_correspondence_games_from_db() -> None:
+                try:
+                    corr_cursor = self.db.game.find({**active_game_filter, "c": True})
+                    corr_cursor.sort("d", -1)
+                    corr_loaded, corr_skipped = await restore_active_games(corr_cursor, corr=True)
+                    log.info(
+                        "Loaded active correspondence games from db: %s loaded, %s skipped",
+                        corr_loaded,
+                        corr_skipped,
+                    )
+                except Exception:
+                    log.exception("Failed to load active correspondence games from db")
+                finally:
+                    self.correspondence_games_loaded.set()
 
             await load_active_simuls(self)
 
@@ -580,6 +622,11 @@ class PychessGlobalAppState:
                     {},  # Empty filter to select all documents
                     [{"$set": {"oauth_id": {"$toLower": "$_id"}, "oauth_provider": "lichess"}}],
                 )
+
+            self.create_background_task(
+                load_correspondence_games_from_db(),
+                name="load-correspondence-games",
+            )
 
         except Exception:
             log.error("init_from_db() Exception")

--- a/server/utils.py
+++ b/server/utils.py
@@ -104,6 +104,20 @@ def should_send_game_start_to_bot(game: Game | GameBug) -> bool:
     return game.variant != "janggi" or not (game.bsetup or game.wsetup)
 
 
+def activate_correspondence_game(game: Game) -> None:
+    """Attach an active correspondence game to its players and restore its clock.
+
+    ``load_game()`` can be called lazily from a game URL before the background
+    correspondence restore has finished. Keep the activation idempotent so both
+    paths may safely touch the same game.
+    """
+    if game not in game.wplayer.correspondence_games:
+        game.wplayer.correspondence_games.append(game)
+    if game not in game.bplayer.correspondence_games:
+        game.bplayer.correspondence_games.append(game)
+    game.stopwatch.restart(from_db=True)
+
+
 async def tv_game(app_state: PychessGlobalAppState):
     """Get latest played game id"""
     if app_state.tv is not None:
@@ -142,15 +156,34 @@ async def load_game(
 
     # log.debug("load_game() %s from db ", game_id)
     doc: GameDocument | None = await app_state.db.game.find_one({"_id": game_id})
-
     if doc is None:
         return None
+
+    return await load_game_from_doc(app_state, doc, cache_finished=cache_finished)
+
+
+async def load_game_from_doc(
+    app_state: PychessGlobalAppState,
+    doc: GameDocument,
+    *,
+    cache_finished: bool = True,
+) -> Game | GameBug | None:
+    """Return Game object from app cache or an already fetched database document.
+
+    Startup restore already iterates over game documents from MongoDB. Parsing the
+    document directly avoids one extra ``find_one({_id: ...})`` round trip for
+    every active game restored during server initialization.
+    """
+    game_id = doc["_id"]
+    if game_id in app_state.games:
+        return app_state.games[game_id]
+
     variant = C2V[doc["v"]]
 
     if doc["v"] in TWO_BOARD_VARIANT_CODES:
-        from bug.utils_bug import load_game_bug
+        from bug.utils_bug import load_game_bug_from_doc
 
-        return await load_game_bug(app_state, game_id, cache_finished=cache_finished)
+        return await load_game_bug_from_doc(app_state, doc, cache_finished=cache_finished)
 
     # log.debug("load_game() parse START")
     wp, bp = doc["us"]
@@ -308,6 +341,9 @@ async def load_game(
         game.board.color = WHITE if game.board.fen.split()[1] == "w" else BLACK
         game.lastmove = mlist[-1]
         game.mct = doc.get("mct")
+
+    if game.corr and game.status <= STARTED:
+        activate_correspondence_game(game)
 
     if game.has_crosstable:
         crosstable_doc = await app_state.db.crosstable.find_one({"_id": game.ct_id})

--- a/server/utils.py
+++ b/server/utils.py
@@ -42,6 +42,7 @@ from fairy import (
     validate_fen,
 )
 from fairy.jieqi import make_initial_mapping
+from clock import CorrClock
 from game import Game
 from newid import new_id
 from seek import (
@@ -115,6 +116,8 @@ def activate_correspondence_game(game: Game) -> None:
         game.wplayer.correspondence_games.append(game)
     if game not in game.bplayer.correspondence_games:
         game.bplayer.correspondence_games.append(game)
+
+    assert isinstance(game.stopwatch, CorrClock)
     game.stopwatch.restart(from_db=True)
 
 


### PR DESCRIPTION
1. delayed background loading of correspondence games
2. startup restore using already-fetched Mongo game documents, avoiding the extra find_one() per game