### PR TITLE
fix: replace invite channel busy-wait with asyncio.Event

### DIFF
--- a/server/bot_api.py
+++ b/server/bot_api.py
@@ -94,18 +94,33 @@ async def challenge_accept(request: web.Request) -> web.StreamResponse:
     result: NewGameMessage | ErrorMessage = await new_game(app_state, seek, gameId)  # noqa: F821
 
     if result["type"] == "new_game":
-        # TODO: use asyncio.Event()
-        wait_count = 0
-        while gameId not in app_state.invite_channels and wait_count < 10:
-            asyncio.sleep(1)  # type: ignore[unused-coroutine]
-            wait_count += 1
-            log.debug("BOT_API challenge_accept() WAITING FOR SSE: %s", wait_count)
+        # Wait for the SSE channel to be registered by subscribe_invites().
+        # Previously this was a bare asyncio.sleep(1) loop (missing await, so
+        # it never actually yielded) — the notification was silently dropped
+        # whenever the channel wasn't ready yet.
+        if gameId not in app_state.invite_channels:
+            event = asyncio.Event()
+            app_state.invite_events[gameId] = event
+            try:
+                # 10 s matches the old busy-wait budget (wait_count < 10 × sleep(1)).
+                await asyncio.wait_for(event.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                log.warning(
+                    "BOT_API challenge_accept() SSE channel timeout for %s", gameId
+                )
+            finally:
+                app_state.invite_events.pop(gameId, None)
 
         try:
             # Put response data to sse subscriber queue
-            channels = app_state.invite_channels[gameId]
-            for queue in channels:
-                await queue.put(json_dumps({"gameId": gameId, "accept": True}))
+            channels = app_state.invite_channels.get(gameId)
+            if channels:
+                for queue in channels:
+                    await queue.put(json_dumps({"gameId": gameId, "accept": True}))
+            else:
+                log.warning(
+                    "BOT_API challenge_accept() no SSE channel found for %s", gameId
+                )
         except ConnectionResetError:
             log.error("/api/challenge/{%s}/accept ConnectionResetError", gameId)
 
@@ -129,18 +144,30 @@ async def challenge_decline(request: web.Request) -> web.StreamResponse:
     if TYPE_CHECKING:
         assert gameId is not None
 
-    # TODO: use asyncio.Event()
-    wait_count = 0
-    while gameId not in app_state.invite_channels and wait_count < 10:
-        await asyncio.sleep(1)
-        wait_count += 1
-        log.debug("BOT_API challenge_decline() WAITING FOR SSE: %s", wait_count)
+    # Wait for the SSE channel to be registered by subscribe_invites().
+    if gameId not in app_state.invite_channels:
+        event = asyncio.Event()
+        app_state.invite_events[gameId] = event
+        try:
+            # 10 s matches the old busy-wait budget (wait_count < 10 × sleep(1)).
+            await asyncio.wait_for(event.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            log.warning(
+                "BOT_API challenge_decline() SSE channel timeout for %s", gameId
+            )
+        finally:
+            app_state.invite_events.pop(gameId, None)
 
     try:
         # Put response data to sse subscriber queue
-        channels = app_state.invite_channels[gameId]
-        for queue in channels:
-            await queue.put(json_dumps({"gameId": gameId, "accept": False}))
+        channels = app_state.invite_channels.get(gameId)
+        if channels:
+            for queue in channels:
+                await queue.put(json_dumps({"gameId": gameId, "accept": False}))
+        else:
+            log.warning(
+                "BOT_API challenge_decline() no SSE channel found for %s", gameId
+            )
     except ConnectionResetError:
         log.error("/api/challenge/{%s}/decline ConnectionResetError", gameId)
 

--- a/server/game_api.py
+++ b/server/game_api.py
@@ -13,7 +13,16 @@ from pymongo.errors import BulkWriteError
 from aiohttp_swagger3 import swagger_doc
 
 from compress import C2R, decode_move_standard
-from const import DARK_FEN, STARTED, MATE, INVALIDMOVE, VARIANTEND, CLAIM, SSE_GET_TIMEOUT, SWISS
+from const import (
+    DARK_FEN,
+    STARTED,
+    MATE,
+    INVALIDMOVE,
+    VARIANTEND,
+    CLAIM,
+    SSE_GET_TIMEOUT,
+    SWISS,
+)
 from convert import zero2grand
 from settings import ADMINS
 from tournament.tournaments import get_tournament_name, load_tournament
@@ -186,7 +195,9 @@ def variant_counts_from_docs(
         except KeyError:
             if variant not in _seen_discontinued_variants:
                 _seen_discontinued_variants.add(variant)
-                log.info("Ignoring discontinued variant %s in historical stats", variant)
+                log.info(
+                    "Ignoring discontinued variant %s in historical stats", variant
+                )
 
 
 async def get_variant_stats(request: web.Request) -> web.StreamResponse:
@@ -229,7 +240,9 @@ async def get_variant_stats(request: web.Request) -> web.StreamResponse:
             docs = await variant_counts_aggregation(app_state, humans)
             variant_counts_from_docs(variant_counts, docs)
 
-        series = [{"name": variant, "data": variant_counts[variant]} for variant in VARIANTS]
+        series = [
+            {"name": variant, "data": variant_counts[variant]} for variant in VARIANTS
+        ]
 
         stats[cur_period] = series
 
@@ -283,7 +296,9 @@ def _parse_positive_int_query_param(request: web.Request, name: str) -> int | No
             text=f"Query parameter '{name}' must be a positive integer."
         ) from error
     if value <= 0:
-        raise web.HTTPBadRequest(text=f"Query parameter '{name}' must be a positive integer.")
+        raise web.HTTPBadRequest(
+            text=f"Query parameter '{name}' must be a positive integer."
+        )
     return value
 
 
@@ -330,9 +345,16 @@ def _build_user_games_filter_cond(
     elif selected_filter == "loss":
         if level is not None:
             filter_cond["$and"] = [
-                {"$or": [{"r": "a", "us.1": profile_id}, {"r": "b", "us.0": profile_id}]},
+                {
+                    "$or": [
+                        {"r": "a", "us.1": profile_id},
+                        {"r": "b", "us.0": profile_id},
+                    ]
+                },
                 {"x": int(level)},
-                {"$or": [{"if": None}, {"v": "j"}]},  # Janggi games always have initial FEN!
+                {
+                    "$or": [{"if": None}, {"v": "j"}]
+                },  # Janggi games always have initial FEN!
                 {
                     "$or": [
                         {"s": MATE},
@@ -348,7 +370,10 @@ def _build_user_games_filter_cond(
                 {"r": "b", "us.0": profile_id},
             ]
     elif selected_filter == "rated":
-        filter_cond["$or"] = [{"y": 1, "us.1": profile_id}, {"y": 1, "us.0": profile_id}]
+        filter_cond["$or"] = [
+            {"y": 1, "us.1": profile_id},
+            {"y": 1, "us.0": profile_id},
+        ]
     elif selected_filter == "playing":
         filter_cond["$and"] = [
             {"$or": [{"c": True, "us.1": profile_id}, {"c": True, "us.0": profile_id}]},
@@ -423,7 +448,9 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
     if TYPE_CHECKING:
         assert profileId is not None
 
-    selected_filter, selected_variant, path_parts = _resolve_user_games_filter_and_variant(request)
+    selected_filter, selected_variant, path_parts = (
+        _resolve_user_games_filter_and_variant(request)
+    )
 
     # print("URL", request.rel_url)
     level = request.rel_url.query.get("x")
@@ -455,7 +482,9 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
             if latest_games is not None:
                 cursor.limit(latest_games)
         else:
-            cursor.sort("d", -1).skip(int(page_num) * GAME_PAGE_SIZE).limit(GAME_PAGE_SIZE)
+            cursor.sort("d", -1).skip(int(page_num) * GAME_PAGE_SIZE).limit(
+                GAME_PAGE_SIZE
+            )
         doc: GameDoc
         async for doc in cursor:
             try:
@@ -467,25 +496,41 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
 
             doc["r"] = C2R[doc["r"]]
             doc["wt"] = (
-                app_state.users[doc["us"][0]].title if doc["us"][0] in app_state.users else ""
+                app_state.users[doc["us"][0]].title
+                if doc["us"][0] in app_state.users
+                else ""
             )
             doc["bt"] = (
-                app_state.users[doc["us"][1]].title if doc["us"][1] in app_state.users else ""
+                app_state.users[doc["us"][1]].title
+                if doc["us"][1] in app_state.users
+                else ""
             )
 
             if len(doc["us"]) > 2:
                 doc["wtB"] = (
-                    app_state.users[doc["us"][2]].title if doc["us"][2] in app_state.users else ""
+                    app_state.users[doc["us"][2]].title
+                    if doc["us"][2] in app_state.users
+                    else ""
                 )
                 doc["btB"] = (
-                    app_state.users[doc["us"][3]].title if doc["us"][3] in app_state.users else ""
+                    app_state.users[doc["us"][3]].title
+                    if doc["us"][3] in app_state.users
+                    else ""
                 )
 
             server_variant = get_server_variant(variant, bool(doc.get("z", 0)))
             decode_method = server_variant.move_decoding
             if server_variant.two_boards:
-                mA = [m for idx, m in enumerate(doc["m"]) if "o" in doc and doc["o"][idx] == 0]
-                mB = [m for idx, m in enumerate(doc["m"]) if "o" in doc and doc["o"][idx] == 1]
+                mA = [
+                    m
+                    for idx, m in enumerate(doc["m"])
+                    if "o" in doc and doc["o"][idx] == 0
+                ]
+                mB = [
+                    m
+                    for idx, m in enumerate(doc["m"])
+                    if "o" in doc and doc["o"][idx] == 1
+                ]
                 doc["lm"] = decode_move_standard(mA[-1]) if len(mA) > 0 else ""
                 doc["lmB"] = decode_move_standard(mB[-1]) if len(mB) > 0 else ""
             else:
@@ -550,12 +595,19 @@ async def subscribe_invites(request: web.Request) -> web.StreamResponse:
         app_state.invite_channels[gameId] = set()
     app_state.invite_channels[gameId].add(queue)
 
+    # Notify any waiting challenge_accept/decline that the channel is now ready.
+    event = app_state.invite_events.get(gameId)
+    if event is not None:
+        event.set()
+
     response: web.StreamResponse = web.Response(status=200)
     try:
         async with sse_response(request) as response:
             while response.is_connected():
                 try:
-                    payload = await asyncio.wait_for(queue.get(), timeout=SSE_GET_TIMEOUT)
+                    payload = await asyncio.wait_for(
+                        queue.get(), timeout=SSE_GET_TIMEOUT
+                    )
                     await response.send(payload)
                     queue.task_done()
                 except asyncio.TimeoutError:
@@ -581,7 +633,9 @@ async def subscribe_games(request: web.Request) -> web.StreamResponse:
         async with sse_response(request) as response:
             while response.is_connected():
                 try:
-                    payload = await asyncio.wait_for(queue.get(), timeout=SSE_GET_TIMEOUT)
+                    payload = await asyncio.wait_for(
+                        queue.get(), timeout=SSE_GET_TIMEOUT
+                    )
                     await response.send(payload)
                     queue.task_done()
                 except asyncio.TimeoutError:
@@ -634,9 +688,14 @@ async def _get_games(request: web.Request) -> web.StreamResponse:
             }
             for game in games
             if game.status == STARTED
-            and ((game.variant == variant and game.chess960 == chess960) if variant else True)
             and (
-                (f"{game.variant}960" if game.chess960 else game.variant) in allowed_variants
+                (game.variant == variant and game.chess960 == chess960)
+                if variant
+                else True
+            )
+            and (
+                (f"{game.variant}960" if game.chess960 else game.variant)
+                in allowed_variants
                 if allowed_variants is not None
                 else True
             )
@@ -680,7 +739,8 @@ async def _stream_pgn_cursor(
                 failed += 1
                 if len(failed_games) < EXPORT_FAILED_SAMPLE_LIMIT:
                     failed_games.append(
-                        "%s %s %s" % (doc["_id"], C2V[doc["v"]], doc["d"].strftime("%Y.%m.%d"))
+                        "%s %s %s"
+                        % (doc["_id"], C2V[doc["v"]], doc["d"].strftime("%Y.%m.%d"))
                     )
                 continue
         log.info("failed/all: %s/%s", failed, game_counter)
@@ -719,7 +779,9 @@ async def export_user_pgn(request: web.Request) -> web.StreamResponse:
     if session_user != profileId and session_user not in ADMINS:
         raise web.HTTPForbidden(text="Users can only export their own games.")
 
-    selected_filter, selected_variant, _path_parts = _resolve_user_games_filter_and_variant(request)
+    selected_filter, selected_variant, _path_parts = (
+        _resolve_user_games_filter_and_variant(request)
+    )
     level = request.rel_url.query.get("x")
     filter_cond = _build_user_games_filter_cond(
         profile_id=profileId,
@@ -775,7 +837,9 @@ async def export_monthly_pgn(request: web.Request) -> web.StreamResponse:
     log.debug("yearmonth: %r %r", yearmonth[:4], yearmonth[4:])
     filter_cond = {
         "$and": [
-            {"$expr": {"s": {"$gt": STARTED}}},  # prevent leaking ongoing fogofwar game info
+            {
+                "$expr": {"s": {"$gt": STARTED}}
+            },  # prevent leaking ongoing fogofwar game info
             {"$expr": {"$eq": [{"$year": "$d"}, int(yearmonth[:4])]}},
             {"$expr": {"$eq": [{"$month": "$d"}, int(yearmonth[4:])]}},
         ]

--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -105,13 +105,17 @@ from push_notifications import PUSH_SUBSCRIPTION_COLLECTION, PushNotifier
 log = logging.getLogger(__name__)
 
 GAME_KEEP_TIME = 1800  # keep game in app[games_key] for GAME_KEEP_TIME secs
-TOURNAMENT_KEEP_TIME = 1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
+TOURNAMENT_KEEP_TIME = (
+    1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
+)
 T = TypeVar("T")
 USERNAME_LOWER_FIELD = "username_lower"
 
 
 def _is_test_run() -> bool:
-    return any("pytest" in arg for arg in sys.argv) or any("unittest" in arg for arg in sys.argv)
+    return any("pytest" in arg for arg in sys.argv) or any(
+        "unittest" in arg for arg in sys.argv
+    )
 
 
 # Local test cache retention; keep this small for test runs, but use the
@@ -165,6 +169,10 @@ class PychessGlobalAppState:
         self.invites: dict[str, Seek] = {}
         self.game_channels: Set[asyncio.Queue[str]] = set()
         self.invite_channels: dict[str, Set[asyncio.Queue[str]]] = {}
+        # Signalled by subscribe_invites() as soon as the SSE channel for a
+        # given gameId is ready. challenge_accept/decline wait on this instead
+        # of busy-polling invite_channels.
+        self.invite_events: dict[str, asyncio.Event] = {}
         self.highscore = {variant: ValueSortedDict(neg) for variant in RATED_VARIANTS}
         self.lobby_leaderboard: list["LobbyLeaderboardEntry"] = []
         self.lobby_tournament_winners: list["TournamentWinnerEntry"] = []
@@ -225,7 +233,9 @@ class PychessGlobalAppState:
                 if doc_id is None:
                     continue
                 update = {key: value for key, value in doc.items() if key != "_id"}
-                await collection.update_one({"_id": doc_id}, {"$set": update}, upsert=True)
+                await collection.update_one(
+                    {"_id": doc_id}, {"$set": update}, upsert=True
+                )
 
         # Read tournaments, users and highscore from db
         try:
@@ -251,7 +261,9 @@ class PychessGlobalAppState:
                 {"$or": [{"status": T_STARTED}, {"status": T_CREATED}]}
             )
             cursor.sort("startsAt", -1)
-            to_date = (datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)).date()
+            to_date = (
+                datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)
+            ).date()
             async for doc in cursor:
                 if doc["status"] == T_STARTED or (
                     doc["status"] == T_CREATED and doc["startsAt"].date() <= to_date
@@ -325,9 +337,15 @@ class PychessGlobalAppState:
             # long enough to delay dyno boot. Keep disabled by default and build via
             # one-off admin/migration job, then keep this gate available for controlled runs.
             if os.getenv("BOOTSTRAP_GAME_PROFILE_COMPOUND_INDEXES", "0") == "1":
-                await self.db.game.create_index([("us", 1), ("d", -1)], name="us_d_desc")
-                await self.db.game.create_index([("us.0", 1), ("d", -1)], name="us0_d_desc")
-                await self.db.game.create_index([("us.1", 1), ("d", -1)], name="us1_d_desc")
+                await self.db.game.create_index(
+                    [("us", 1), ("d", -1)], name="us_d_desc"
+                )
+                await self.db.game.create_index(
+                    [("us.0", 1), ("d", -1)], name="us0_d_desc"
+                )
+                await self.db.game.create_index(
+                    [("us.1", 1), ("d", -1)], name="us1_d_desc"
+                )
                 await self.db.game.create_index(
                     [("us.0", 1), ("us.1", 1), ("d", -1)],
                     name="us0_us1_d_desc",
@@ -391,7 +409,9 @@ class PychessGlobalAppState:
 
             if "security_ban_signal" not in db_collections:
                 await self.db.create_collection("security_ban_signal")
-            await self.db.security_ban_signal.create_index("expireAt", expireAfterSeconds=0)
+            await self.db.security_ban_signal.create_index(
+                "expireAt", expireAfterSeconds=0
+            )
 
             # Load auto pairings from database
             async for doc in self.db.autopairing.find():
@@ -432,7 +452,9 @@ class PychessGlobalAppState:
                         challenge_decline_reason=doc.get("challengeDeclineReason"),
                     )
                     if not should_restore_persisted_seek(seek):
-                        log.debug("Skipping non-restorable seek from database: %s", seek.id)
+                        log.debug(
+                            "Skipping non-restorable seek from database: %s", seek.id
+                        )
                         continue
                     log.debug("Loading seek from database: %s" % seek)
                     self.seeks[seek.id] = seek
@@ -492,7 +514,9 @@ class PychessGlobalAppState:
                 async for doc in cursor:
                     if corr:
                         # Don't load old never-started correspondence games.
-                        if doc["s"] == -2 and doc["d"] < today - timedelta(days=doc.get("b", 1)):
+                        if doc["s"] == -2 and doc["d"] < today - timedelta(
+                            days=doc.get("b", 1)
+                        ):
                             skipped += 1
                             continue
                     else:
@@ -519,7 +543,9 @@ class PychessGlobalAppState:
                 }
             )
             live_cursor.sort("d", -1)
-            live_loaded, live_skipped = await restore_active_games(live_cursor, corr=False)
+            live_loaded, live_skipped = await restore_active_games(
+                live_cursor, corr=False
+            )
             log.info(
                 "Loaded active live games from db: %s loaded, %s skipped",
                 live_loaded,
@@ -530,7 +556,9 @@ class PychessGlobalAppState:
                 try:
                     corr_cursor = self.db.game.find({**active_game_filter, "c": True})
                     corr_cursor.sort("d", -1)
-                    corr_loaded, corr_skipped = await restore_active_games(corr_cursor, corr=True)
+                    corr_loaded, corr_skipped = await restore_active_games(
+                        corr_cursor, corr=True
+                    )
                     log.info(
                         "Loaded active correspondence games from db: %s loaded, %s skipped",
                         corr_loaded,
@@ -546,7 +574,9 @@ class PychessGlobalAppState:
             await upsert_static_docs(self.db.video, VIDEOS)
             if "ublog_post" not in db_collections:
                 await self.db.create_collection("ublog_post")
-            await self.db.ublog_post.create_index([("author", 1), ("live", 1), ("publishedAt", -1)])
+            await self.db.ublog_post.create_index(
+                [("author", 1), ("live", 1), ("publishedAt", -1)]
+            )
             await self.db.ublog_post.create_index(
                 [("live", 1), ("sticky", -1), ("publishedAt", -1)]
             )
@@ -565,7 +595,9 @@ class PychessGlobalAppState:
                 if ublog_post_count == 0:
                     from legacy_blog_migration import build_legacy_ublog_docs
 
-                    legacy_blog_author_policy = os.getenv("LEGACY_BLOG_AUTHOR_POLICY", "keep")
+                    legacy_blog_author_policy = os.getenv(
+                        "LEGACY_BLOG_AUTHOR_POLICY", "keep"
+                    )
                     if legacy_blog_author_policy not in ("keep", "official-as-pychess"):
                         legacy_blog_author_policy = "keep"
                     await upsert_static_docs(
@@ -620,7 +652,14 @@ class PychessGlobalAppState:
             if userCollectionHasLichessOauth2Fields is None:
                 await self.db.user.update_many(
                     {},  # Empty filter to select all documents
-                    [{"$set": {"oauth_id": {"$toLower": "$_id"}, "oauth_provider": "lichess"}}],
+                    [
+                        {
+                            "$set": {
+                                "oauth_id": {"$toLower": "$_id"},
+                                "oauth_provider": "lichess",
+                            }
+                        }
+                    ],
                 )
 
             self.create_background_task(
@@ -650,7 +689,9 @@ class PychessGlobalAppState:
 
             # Create translation class
             try:
-                translation = gettext.translation("server", localedir="lang", languages=[lang])
+                translation = gettext.translation(
+                    "server", localedir="lang", languages=[lang]
+                )
             except FileNotFoundError:
                 log.warning("Missing translations file for lang %s", lang)
                 translation = gettext.NullTranslations()
@@ -666,13 +707,19 @@ class PychessGlobalAppState:
                     or variant in SEATURDAY
                     or variant in PAUSED_MONTHLY_VARIANTS
                 ):
-                    tname = translated_tournament_name(variant, MONTHLY, ARENA, translation)
+                    tname = translated_tournament_name(
+                        variant, MONTHLY, ARENA, translation
+                    )
                     self.tourneynames[lang][(variant, MONTHLY, ARENA)] = tname
                 if variant in SEATURDAY or variant in WEEKLY_VARIANTS:
-                    tname = translated_tournament_name(variant, WEEKLY, ARENA, translation)
+                    tname = translated_tournament_name(
+                        variant, WEEKLY, ARENA, translation
+                    )
                     self.tourneynames[lang][(variant, WEEKLY, ARENA)] = tname
                 if variant in SHIELDS:
-                    tname = translated_tournament_name(variant, SHIELD, ARENA, translation)
+                    tname = translated_tournament_name(
+                        variant, SHIELD, ARENA, translation
+                    )
                     self.tourneynames[lang][(variant, SHIELD, ARENA)] = tname
 
         # https://github.com/aio-libs/aiohttp-jinja2/issues/187#issuecomment-2519831516
@@ -821,7 +868,11 @@ class PychessGlobalAppState:
                 if removed is None:
                     # The queue may already be gone when cleanup runs after
                     # reconnect/disconnect races or repeated cache removals.
-                    log.debug("%s already missing from %s.game_queues", game.id, player.username)
+                    log.debug(
+                        "%s already missing from %s.game_queues",
+                        game.id,
+                        player.username,
+                    )
 
         for player in game.all_players:
             if player.game_in_progress == game.id:
@@ -848,7 +899,9 @@ class PychessGlobalAppState:
         self.game_remove_tasks.pop(game.id, None)
         await self._evict_game_from_cache(game)
 
-    async def maybe_remove_finished_game_from_cache_now(self, game: Game | GameBug) -> None:
+    async def maybe_remove_finished_game_from_cache_now(
+        self, game: Game | GameBug
+    ) -> None:
         if game.status <= STARTED or game.id not in self.games:
             return
 
@@ -857,10 +910,15 @@ class PychessGlobalAppState:
         if has_pending_analysis_work_for_game(self, game.id):
             return
 
-        if any(player.is_user_active_in_game(game.id) for player in game.non_bot_players):
+        if any(
+            player.is_user_active_in_game(game.id) for player in game.non_bot_players
+        ):
             return
 
-        if any(spectator.is_user_active_in_game(game.id) for spectator in tuple(game.spectators)):
+        if any(
+            spectator.is_user_active_in_game(game.id)
+            for spectator in tuple(game.spectators)
+        ):
             return
 
         await self.remove_game_from_cache_now(game)
@@ -880,7 +938,9 @@ class PychessGlobalAppState:
         return result
 
     async def remove_from_cache(self, game):
-        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME)
+        await asyncio.sleep(
+            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME
+        )
         await self._evict_game_from_cache(game)
 
     def schedule_tournament_cache_removal(self, tournament: Tournament):
@@ -903,7 +963,9 @@ class PychessGlobalAppState:
         task.add_done_callback(_cleanup_task)
 
     async def remove_tournament_from_cache(self, tournament_id: str):
-        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME)
+        await asyncio.sleep(
+            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME
+        )
 
         tournament = self.tournaments.get(tournament_id)
         if tournament is None or tournament.status <= T_STARTED:
@@ -1077,7 +1139,9 @@ class PychessGlobalAppState:
         return sum((1 for user in self.users.values() if user.online))
 
     def auto_pairing_count(self):
-        return sum((1 for user in self.auto_pairing_users if user.ready_for_auto_pairing))
+        return sum(
+            (1 for user in self.auto_pairing_users if user.ready_for_auto_pairing)
+        )
 
     def __str__(self):
         return self.__stringify(str)

--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -101,21 +101,18 @@ import sys
 from variants import VARIANTS, RATED_VARIANTS
 from puzzle import rename_puzzle_fields
 from push_notifications import PUSH_SUBSCRIPTION_COLLECTION, PushNotifier
+from startup_timer import StartupTimer
 
 log = logging.getLogger(__name__)
 
 GAME_KEEP_TIME = 1800  # keep game in app[games_key] for GAME_KEEP_TIME secs
-TOURNAMENT_KEEP_TIME = (
-    1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
-)
+TOURNAMENT_KEEP_TIME = 1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
 T = TypeVar("T")
 USERNAME_LOWER_FIELD = "username_lower"
 
 
 def _is_test_run() -> bool:
-    return any("pytest" in arg for arg in sys.argv) or any(
-        "unittest" in arg for arg in sys.argv
-    )
+    return any("pytest" in arg for arg in sys.argv) or any("unittest" in arg for arg in sys.argv)
 
 
 # Local test cache retention; keep this small for test runs, but use the
@@ -130,101 +127,115 @@ class PychessGlobalAppState:
     def __init__(self, app: web.Application):
         from typedefs import db_key
 
-        self.app = app
-        self.anon_as_test_users = app[anon_as_test_users_key]
+        startup = StartupTimer(log, "PychessGlobalAppState.__init__")
 
-        self.shutdown = False
-        self.tournaments_loaded = asyncio.Event()
-        self.correspondence_games_loaded = asyncio.Event()
+        with startup.phase("initialize core state"):
+            self.app = app
+            self.anon_as_test_users = app[anon_as_test_users_key]
 
-        self.db_client = app[client_key]
-        self.db: Any = app[db_key]
-        self.users = self.__init_users()
-        self.public_users = PublicUsers(self)
-        self.disable_new_anons = False
-        self.lobby = Lobby(self)
-        self.chat_flood = ChatFlood()
-        # one dict per tournament! {tournamentId: {user.username: user.tournament_sockets, ...}, ...}
-        self.tourneysockets: dict[str, dict[str, set[WebSocketResponse | None]]] = {}
-        self.background_tasks: set[asyncio.Task[Any]] = set()
-        self.game_remove_tasks: dict[str, asyncio.Task[None]] = {}
-        self.tournament_remove_tasks: dict[str, asyncio.Task[None]] = {}
+            self.shutdown = False
+            self.tournaments_loaded = asyncio.Event()
+            self.correspondence_games_loaded = asyncio.Event()
 
-        # translated scheduled tournament names {(variant, frequency, t_type): tournament.name, ...}
-        self.tourneynames: dict[str, dict] = {lang: {} for lang in LANGUAGES}
+            self.db_client = app[client_key]
+            self.db: Any = app[db_key]
+            self.users = self.__init_users()
+            self.public_users = PublicUsers(self)
+            self.disable_new_anons = False
+            self.lobby = Lobby(self)
+            self.chat_flood = ChatFlood()
+            # one dict per tournament! {tournamentId: {user.username: user.tournament_sockets, ...}, ...}
+            self.tourneysockets: dict[str, dict[str, set[WebSocketResponse | None]]] = {}
+            self.background_tasks: set[asyncio.Task[Any]] = set()
+            self.game_remove_tasks: dict[str, asyncio.Task[None]] = {}
+            self.tournament_remove_tasks: dict[str, asyncio.Task[None]] = {}
 
-        self.tournaments: dict[str, Tournament] = {}
-        self.simuls: dict[str, Simul] = {}
+            # translated scheduled tournament names {(variant, frequency, t_type): tournament.name, ...}
+            self.tourneynames: dict[str, dict] = {lang: {} for lang in LANGUAGES}
 
-        self.tourney_calendar = None
+            self.tournaments: dict[str, Tournament] = {}
+            self.simuls: dict[str, Simul] = {}
 
-        # lichess allows 7 team message per week, so we will send one (cumulative) per day only
-        # TODO: save/restore from db
-        self.sent_lichess_team_msg: List[date] = []
+            self.tourney_calendar = None
 
-        self.seeks: dict[str, Seek] = {}
-        self.auto_pairing_users: dict[User, tuple[int, int]] = {}
-        self.auto_pairings: dict[tuple[str, bool, int, int, int], set[User]] = {}
-        self.games: dict[str, Game | GameBug] = {}
-        self.invites: dict[str, Seek] = {}
-        self.game_channels: Set[asyncio.Queue[str]] = set()
-        self.invite_channels: dict[str, Set[asyncio.Queue[str]]] = {}
-        # Signalled by subscribe_invites() as soon as the SSE channel for a
-        # given gameId is ready. challenge_accept/decline wait on this instead
-        # of busy-polling invite_channels.
-        self.invite_events: dict[str, asyncio.Event] = {}
-        self.highscore = {variant: ValueSortedDict(neg) for variant in RATED_VARIANTS}
-        self.lobby_leaderboard: list["LobbyLeaderboardEntry"] = []
-        self.lobby_tournament_winners: list["TournamentWinnerEntry"] = []
-        self.shield = {}
-        self.shield_owners = {}  # {variant: username, ...}
-        self.daily_puzzle_ids = {}  # {date or date:category: puzzle._id, ...}
+            # lichess allows 7 team message per week, so we will send one (cumulative) per day only
+            # TODO: save/restore from db
+            self.sent_lichess_team_msg: List[date] = []
 
-        # monthly game stats per variant
-        self.stats = {}
-        self.stats_humans = {}
+            self.seeks: dict[str, Seek] = {}
+            self.auto_pairing_users: dict[User, tuple[int, int]] = {}
+            self.auto_pairings: dict[tuple[str, bool, int, int, int], set[User]] = {}
+            self.games: dict[str, Game | GameBug] = {}
+            self.invites: dict[str, Seek] = {}
+            self.game_channels: Set[asyncio.Queue[str]] = set()
+            self.invite_channels: dict[str, Set[asyncio.Queue[str]]] = {}
+            # asyncio.Event per invite game_id; allows awaiters to be signalled
+            # when an invite is accepted, declined, or cancelled.
+            self.invite_events: dict[str, asyncio.Event] = {}
+            self.highscore = {variant: ValueSortedDict(neg) for variant in RATED_VARIANTS}
+            self.lobby_leaderboard: list["LobbyLeaderboardEntry"] = []
+            self.lobby_tournament_winners: list["TournamentWinnerEntry"] = []
+            self.shield = {}
+            self.shield_owners = {}  # {variant: username, ...}
+            self.daily_puzzle_ids = {}  # {date or date:category: puzzle._id, ...}
 
-        # counters for games
-        self.g_cnt = [0]
+            # monthly game stats per variant
+            self.stats = {}
+            self.stats_humans = {}
 
-        # last game played
-        self.tv: str | None = None
+            # counters for games
+            self.g_cnt = [0]
 
-        self.twitch = self.__init_twitch()
-        self.youtube = Youtube(self.app)
+            # last game played
+            self.tv: str | None = None
 
-        # fishnet active workers
-        self.workers = set()
-        self.fishnet_worker_last_seen: dict[str, float] = {}
-        # fishnet works
-        self.fishnet_works = {}
-        # fishnet worker tasks
-        self.fishnet_queue = asyncio.PriorityQueue()
-        # fishnet workers monitor
-        self.fishnet_monitor = self.__init_fishnet_monitor()
-        self.fishnet_versions = {}
+        with startup.phase("initialize streaming + worker helpers"):
+            self.twitch = self.__init_twitch()
+            self.youtube = Youtube(self.app)
 
-        # Configure translations
-        self.translations = {}
+            # fishnet active workers
+            self.workers = set()
+            self.fishnet_worker_last_seen: dict[str, float] = {}
+            # fishnet works
+            self.fishnet_works = {}
+            # fishnet worker tasks
+            self.fishnet_queue = asyncio.PriorityQueue()
+            # fishnet workers monitor
+            self.fishnet_monitor = self.__init_fishnet_monitor()
+            self.fishnet_versions = {}
 
-        # self.discord:
-        self.__init_discord()
+            # Configure translations
+            self.translations = {}
 
-        #####
-        # This is set by __start_gc_stats_logger() if telemetry is enabled.
-        self.gc_stats_task = None
+            #####
+            # This is set by __start_gc_stats_logger() if telemetry is enabled.
+            self.gc_stats_task = None
 
-        self.__start_bots()
-        self.__init_translations()
-        self.__start_gc_stats_logger()
+        with startup.phase("initialize discord"):
+            self.__init_discord()
 
-        self.started_at = datetime.now(timezone.utc)
-        self.push_notifier = PushNotifier(self)
-        if self.push_notifier.enabled:
-            self.create_background_task(self.push_notifier.run(), name="push-notifier")
+        with startup.phase("start bots"):
+            self.__start_bots()
+
+        with startup.phase("initialize translations"):
+            self.__init_translations()
+
+        with startup.phase("start gc telemetry"):
+            self.__start_gc_stats_logger()
+
+        with startup.phase("start push notifier"):
+            self.started_at = datetime.now(timezone.utc)
+            self.push_notifier = PushNotifier(self)
+            if self.push_notifier.enabled:
+                self.create_background_task(self.push_notifier.run(), name="push-notifier")
+
+        startup.log_summary()
 
     async def init_from_db(self):
+        startup = StartupTimer(log, "PychessGlobalAppState.init_from_db")
         if self.db is None:
+            log.debug("[startup] PychessGlobalAppState.init_from_db skipped: no database")
+            startup.log_summary()
             return
 
         async def upsert_static_docs(collection, docs):
@@ -233,234 +244,224 @@ class PychessGlobalAppState:
                 if doc_id is None:
                     continue
                 update = {key: value for key, value in doc.items() if key != "_id"}
-                await collection.update_one(
-                    {"_id": doc_id}, {"$set": update}, upsert=True
-                )
+                await collection.update_one({"_id": doc_id}, {"$set": update}, upsert=True)
 
         # Read tournaments, users and highscore from db
         try:
-            db_collections = await self.db.list_collection_names()
+            with startup.phase("preflight collections + tournament indexes"):
+                db_collections = await self.db.list_collection_names()
 
-            puzzle = await self.db.puzzle.find_one()
-            puzzle_doc_rename_needed = (puzzle is not None) and ("variant" in puzzle)
-            if puzzle_doc_rename_needed:
-                await rename_puzzle_fields(self.db)
+                puzzle = await self.db.puzzle.find_one()
+                puzzle_doc_rename_needed = (puzzle is not None) and ("variant" in puzzle)
+                if puzzle_doc_rename_needed:
+                    await rename_puzzle_fields(self.db)
 
-            if "tournament_chat" not in db_collections:
-                await self.db.create_collection("tournament_chat")
+                if "tournament_chat" not in db_collections:
+                    await self.db.create_collection("tournament_chat")
                 await self.db.tournament_chat.create_index("tid")
 
-            if "simul_chat" not in db_collections:
-                await self.db.create_collection("simul_chat")
+                if "simul_chat" not in db_collections:
+                    await self.db.create_collection("simul_chat")
                 await self.db.simul_chat.create_index("sid")
 
-            await self.db.tournament.create_index("startsAt")
-            await self.db.tournament.create_index("status")
+                await self.db.tournament.create_index("startsAt")
+                await self.db.tournament.create_index("status")
+                await self.db.tournament_player.create_index("tid")
+                await self.db.tournament_pairing.create_index("tid")
 
-            cursor = self.db.tournament.find(
-                {"$or": [{"status": T_STARTED}, {"status": T_CREATED}]}
-            )
-            cursor.sort("startsAt", -1)
-            to_date = (
-                datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)
-            ).date()
-            async for doc in cursor:
-                if doc["status"] == T_STARTED or (
-                    doc["status"] == T_CREATED and doc["startsAt"].date() <= to_date
-                ):
-                    await load_tournament(self, doc["_id"])
-            self.tournaments_loaded.set()
+            with startup.phase("restore tournaments"):
+                cursor = self.db.tournament.find(
+                    {"$or": [{"status": T_STARTED}, {"status": T_CREATED}]}
+                )
+                cursor.sort("startsAt", -1)
+                to_date = (datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)).date()
+                async for doc in cursor:
+                    if doc["status"] == T_STARTED or (
+                        doc["status"] == T_CREATED and doc["startsAt"].date() <= to_date
+                    ):
+                        await load_tournament(self, doc["_id"])
+                self.tournaments_loaded.set()
 
-            already_scheduled = await get_scheduled_tournaments(self)
-            new_tournaments_data = new_scheduled_tournaments(already_scheduled)
-            await create_scheduled_tournaments(self, new_tournaments_data)
+            with startup.phase("create missing scheduled tournaments"):
+                already_scheduled = await get_scheduled_tournaments(self)
+                new_tournaments_data = new_scheduled_tournaments(already_scheduled)
+                await create_scheduled_tournaments(self, new_tournaments_data)
 
-            self.create_background_task(generate_shield(self), name="generate-shield")
+            with startup.phase("restore highscore + lobby caches"):
+                self.create_background_task(generate_shield(self), name="generate-shield")
 
-            if "highscore" not in db_collections:
-                await generate_highscore(self)
-            cursor = self.db.highscore.find()
-            async for doc in cursor:
-                if doc["_id"] in self.highscore:
-                    self.highscore[doc["_id"]] = ValueSortedDict(neg, doc["scores"])
-            await refresh_lobby_leaderboard_cache(self)
-            await refresh_lobby_tournament_winners_cache(self)
+                if "highscore" not in db_collections:
+                    await generate_highscore(self)
+                cursor = self.db.highscore.find()
+                async for doc in cursor:
+                    if doc["_id"] in self.highscore:
+                        self.highscore[doc["_id"]] = ValueSortedDict(neg, doc["scores"])
+                await refresh_lobby_leaderboard_cache(self)
+                await refresh_lobby_tournament_winners_cache(self)
 
-            if "crosstable" not in db_collections:
-                await generate_crosstable(self)
+                if "crosstable" not in db_collections:
+                    await generate_crosstable(self)
 
-            if "dailypuzzle" not in db_collections:
-                try:
-                    daily_max = 365 * len(GAME_CATEGORIES)
-                    await self.db.create_collection(
-                        "dailypuzzle",
-                        capped=True,
-                        size=50000,
-                        max=daily_max,
+            with startup.phase("bootstrap collections + indexes"):
+                if "dailypuzzle" not in db_collections:
+                    try:
+                        daily_max = 365 * len(GAME_CATEGORIES)
+                        await self.db.create_collection(
+                            "dailypuzzle",
+                            capped=True,
+                            size=50000,
+                            max=daily_max,
+                        )
+                    except NotImplementedError:
+                        await self.db.create_collection("dailypuzzle")
+                else:
+                    cursor = self.db.dailypuzzle.find()
+                    docs = await cursor.to_list(length=365 * len(GAME_CATEGORIES))
+                    self.daily_puzzle_ids = {doc["_id"]: doc["puzzleId"] for doc in docs}
+
+                if "lobbychat" not in db_collections:
+                    try:
+                        await self.db.create_collection(
+                            "lobbychat", capped=True, size=100000, max=MAX_CHAT_LINES
+                        )
+                    except NotImplementedError:
+                        await self.db.create_collection("lobbychat")
+                else:
+                    cursor = self.db.lobbychat.find(
+                        projection={
+                            "_id": 0,
+                            "type": 1,
+                            "user": 1,
+                            "message": 1,
+                            "room": 1,
+                            "time": 1,
+                        }
                     )
-                except NotImplementedError:
-                    await self.db.create_collection("dailypuzzle")
-            else:
-                cursor = self.db.dailypuzzle.find()
-                docs = await cursor.to_list(length=365 * len(GAME_CATEGORIES))
-                self.daily_puzzle_ids = {doc["_id"]: doc["puzzleId"] for doc in docs}
+                    docs = await cursor.to_list(length=MAX_CHAT_LINES)
+                    self.lobby.lobbychat = collections.deque(docs, MAX_CHAT_LINES)
 
-            if "lobbychat" not in db_collections:
-                try:
-                    await self.db.create_collection(
-                        "lobbychat", capped=True, size=100000, max=MAX_CHAT_LINES
-                    )
-                except NotImplementedError:
-                    await self.db.create_collection("lobbychat")
-            else:
-                cursor = self.db.lobbychat.find(
-                    projection={
-                        "_id": 0,
-                        "type": 1,
-                        "user": 1,
-                        "message": 1,
-                        "room": 1,
-                        "time": 1,
-                    }
-                )
-                docs = await cursor.to_list(length=MAX_CHAT_LINES)
-                self.lobby.lobbychat = collections.deque(docs, MAX_CHAT_LINES)
-
-            await self.db.game.create_index("us")
-            await self.db.game.create_index("r")
-            await self.db.game.create_index("v")
-            await self.db.game.create_index("y")
-            await self.db.game.create_index("by")
-            await self.db.game.create_index("c")
-            # NOTE:
-            # Building these compound indexes on a large production collection can take
-            # long enough to delay dyno boot. Keep disabled by default and build via
-            # one-off admin/migration job, then keep this gate available for controlled runs.
-            if os.getenv("BOOTSTRAP_GAME_PROFILE_COMPOUND_INDEXES", "0") == "1":
-                await self.db.game.create_index(
-                    [("us", 1), ("d", -1)], name="us_d_desc"
-                )
-                await self.db.game.create_index(
-                    [("us.0", 1), ("d", -1)], name="us0_d_desc"
-                )
-                await self.db.game.create_index(
-                    [("us.1", 1), ("d", -1)], name="us1_d_desc"
-                )
+                await self.db.game.create_index("us")
+                await self.db.game.create_index("r")
+                await self.db.game.create_index("v")
+                await self.db.game.create_index("y")
+                await self.db.game.create_index("by")
+                await self.db.game.create_index("c")
+                await self.db.game.create_index("tid")
+                await self.db.game.create_index([("us", 1), ("d", -1)], name="us_d_desc")
+                await self.db.game.create_index([("us.0", 1), ("d", -1)], name="us0_d_desc")
+                await self.db.game.create_index([("us.1", 1), ("d", -1)], name="us1_d_desc")
                 await self.db.game.create_index(
                     [("us.0", 1), ("us.1", 1), ("d", -1)],
                     name="us0_us1_d_desc",
                 )
 
-            if "notify" not in db_collections:
-                await self.db.create_collection("notify")
-            await self.db.notify.create_index("notifies")
-            await self.db.notify.create_index("expireAt", expireAfterSeconds=0)
+                if "notify" not in db_collections:
+                    await self.db.create_collection("notify")
+                await self.db.notify.create_index("notifies")
+                await self.db.notify.create_index("expireAt", expireAfterSeconds=0)
 
-            if PUSH_SUBSCRIPTION_COLLECTION not in db_collections:
-                await self.db.create_collection(PUSH_SUBSCRIPTION_COLLECTION)
-            await self.db[PUSH_SUBSCRIPTION_COLLECTION].create_index("user")
-            await self.db[PUSH_SUBSCRIPTION_COLLECTION].create_index("seenAt")
-            await self.db[PUSH_SUBSCRIPTION_COLLECTION].create_index(
-                [("user", 1), ("endpoint", 1)],
-                unique=True,
-                name="push_user_endpoint",
-            )
+                if PUSH_SUBSCRIPTION_COLLECTION not in db_collections:
+                    await self.db.create_collection(PUSH_SUBSCRIPTION_COLLECTION)
+                await self.db[PUSH_SUBSCRIPTION_COLLECTION].create_index("user")
+                await self.db[PUSH_SUBSCRIPTION_COLLECTION].create_index("seenAt")
+                await self.db[PUSH_SUBSCRIPTION_COLLECTION].create_index(
+                    [("user", 1), ("endpoint", 1)],
+                    unique=True,
+                    name="push_user_endpoint",
+                )
 
-            if "inbox_thread" not in db_collections:
-                await self.db.create_collection("inbox_thread")
-            await self.db.inbox_thread.create_index("users")
-            await self.db.inbox_thread.create_index("updatedAt")
+                if "inbox_thread" not in db_collections:
+                    await self.db.create_collection("inbox_thread")
+                await self.db.inbox_thread.create_index("users")
+                await self.db.inbox_thread.create_index("updatedAt")
 
-            if "inbox_msg" not in db_collections:
-                await self.db.create_collection("inbox_msg")
-            await self.db.inbox_msg.create_index([("tid", 1), ("createdAt", 1)])
+                if "inbox_msg" not in db_collections:
+                    await self.db.create_collection("inbox_msg")
+                await self.db.inbox_msg.create_index([("tid", 1), ("createdAt", 1)])
 
-            if "forum_categ" not in db_collections:
-                await self.db.create_collection("forum_categ")
-            await self.db.forum_categ.create_index("order")
+                if "forum_categ" not in db_collections:
+                    await self.db.create_collection("forum_categ")
+                await self.db.forum_categ.create_index("order")
 
-            if "forum_topic" not in db_collections:
-                await self.db.create_collection("forum_topic")
-            await self.db.forum_topic.create_index(
-                [("categId", 1), ("sticky", -1), ("updatedAt", -1)]
-            )
-            await self.db.forum_topic.create_index(
-                [("categId", 1), ("slug", 1)],
-                unique=True,
-                name="forum_topic_categ_slug",
-            )
+                if "forum_topic" not in db_collections:
+                    await self.db.create_collection("forum_topic")
+                await self.db.forum_topic.create_index(
+                    [("categId", 1), ("sticky", -1), ("updatedAt", -1)]
+                )
+                await self.db.forum_topic.create_index(
+                    [("categId", 1), ("slug", 1)],
+                    unique=True,
+                    name="forum_topic_categ_slug",
+                )
 
-            if "forum_post" not in db_collections:
-                await self.db.create_collection("forum_post")
-            await self.db.forum_post.create_index([("topicId", 1), ("createdAt", 1)])
-            await self.db.forum_post.create_index([("categId", 1), ("createdAt", -1)])
-            await self.db.forum_post.create_index([("text", "text")])
+                if "forum_post" not in db_collections:
+                    await self.db.create_collection("forum_post")
+                await self.db.forum_post.create_index([("topicId", 1), ("createdAt", 1)])
+                await self.db.forum_post.create_index([("categId", 1), ("createdAt", -1)])
+                await self.db.forum_post.create_index([("text", "text")])
 
-            if "user_report" not in db_collections:
-                await self.db.create_collection("user_report")
-            await self.db.user_report.create_index("createdAt")
-            await self.db.user_report.create_index("status")
-            await self.db.user_report.create_index("reporter")
-            await self.db.user_report.create_index("suspect")
+                if "user_report" not in db_collections:
+                    await self.db.create_collection("user_report")
+                await self.db.user_report.create_index("createdAt")
+                await self.db.user_report.create_index("status")
+                await self.db.user_report.create_index("reporter")
+                await self.db.user_report.create_index("suspect")
 
-            if "seek" not in db_collections:
-                await self.db.create_collection("seek")
-            await self.db.seek.create_index("expireAt", expireAfterSeconds=0)
+                if "seek" not in db_collections:
+                    await self.db.create_collection("seek")
+                await self.db.seek.create_index("expireAt", expireAfterSeconds=0)
 
-            if "security_ban_signal" not in db_collections:
-                await self.db.create_collection("security_ban_signal")
-            await self.db.security_ban_signal.create_index(
-                "expireAt", expireAfterSeconds=0
-            )
+                if "security_ban_signal" not in db_collections:
+                    await self.db.create_collection("security_ban_signal")
+                await self.db.security_ban_signal.create_index("expireAt", expireAfterSeconds=0)
 
-            # Load auto pairings from database
-            async for doc in self.db.autopairing.find():
-                variant_tc = tuple(doc["variant_tc"])
-                if variant_tc not in self.auto_pairings:
-                    self.auto_pairings[variant_tc] = set()
+            with startup.phase("restore autopairings + seeks"):
+                # Load auto pairings from database
+                async for doc in self.db.autopairing.find():
+                    variant_tc = tuple(doc["variant_tc"])
+                    if variant_tc not in self.auto_pairings:
+                        self.auto_pairings[variant_tc] = set()
 
-                for username, rrange in doc["users"]:
-                    user = await self.users.get(username)
-                    self.auto_pairings[variant_tc].add(user)
-                    if user not in self.auto_pairing_users:
-                        self.auto_pairing_users[user] = rrange
+                    for username, rrange in doc["users"]:
+                        user = await self.users.get(username)
+                        self.auto_pairings[variant_tc].add(user)
+                        if user not in self.auto_pairing_users:
+                            self.auto_pairing_users[user] = rrange
 
-            # Load seeks from database
-            async for doc in self.db.seek.find():
-                user = await self.users.get(doc["user"])
-                if user is not None:
-                    game_id = doc.get("gameId") or None
-                    seek = Seek(
-                        doc["_id"],
-                        user,
-                        doc["variant"],
-                        fen=doc["fen"],
-                        color=doc["color"],
-                        base=doc.get("base", 5),
-                        inc=doc.get("inc", 5),
-                        byoyomi_period=doc.get("byoyomi", 0),
-                        day=doc["day"],
-                        rated=doc["rated"],
-                        rrmin=doc.get("rrmin"),
-                        rrmax=doc.get("rrmax"),
-                        chess960=doc["chess960"],
-                        target=doc.get("target"),
-                        game_id=game_id,
-                        player1=user,
-                        expire_at=doc.get("expireAt"),
-                        challenge_status=doc.get("challengeStatus"),
-                        challenge_decline_reason=doc.get("challengeDeclineReason"),
-                    )
-                    if not should_restore_persisted_seek(seek):
-                        log.debug(
-                            "Skipping non-restorable seek from database: %s", seek.id
+                # Load seeks from database
+                async for doc in self.db.seek.find():
+                    user = await self.users.get(doc["user"])
+                    if user is not None:
+                        game_id = doc.get("gameId") or None
+                        seek = Seek(
+                            doc["_id"],
+                            user,
+                            doc["variant"],
+                            fen=doc["fen"],
+                            color=doc["color"],
+                            base=doc.get("base", 5),
+                            inc=doc.get("inc", 5),
+                            byoyomi_period=doc.get("byoyomi", 0),
+                            day=doc["day"],
+                            rated=doc["rated"],
+                            rrmin=doc.get("rrmin"),
+                            rrmax=doc.get("rrmax"),
+                            chess960=doc["chess960"],
+                            target=doc.get("target"),
+                            game_id=game_id,
+                            player1=user,
+                            expire_at=doc.get("expireAt"),
+                            challenge_status=doc.get("challengeStatus"),
+                            challenge_decline_reason=doc.get("challengeDeclineReason"),
                         )
-                        continue
-                    log.debug("Loading seek from database: %s" % seek)
-                    self.seeks[seek.id] = seek
-                    user.seeks[seek.id] = seek
-                    if game_id is not None:
-                        self.invites[game_id] = seek
+                        if not should_restore_persisted_seek(seek):
+                            log.debug("Skipping non-restorable seek from database: %s", seek.id)
+                            continue
+                        log.debug("Loading seek from database: %s" % seek)
+                        self.seeks[seek.id] = seek
+                        user.seeks[seek.id] = seek
+                        if game_id is not None:
+                            self.invites[game_id] = seek
 
             # Read games in play and start their clocks.
             #
@@ -514,9 +515,7 @@ class PychessGlobalAppState:
                 async for doc in cursor:
                     if corr:
                         # Don't load old never-started correspondence games.
-                        if doc["s"] == -2 and doc["d"] < today - timedelta(
-                            days=doc.get("b", 1)
-                        ):
+                        if doc["s"] == -2 and doc["d"] < today - timedelta(days=doc.get("b", 1)):
                             skipped += 1
                             continue
                     else:
@@ -535,30 +534,27 @@ class PychessGlobalAppState:
                         skipped += 1
                 return loaded, skipped
 
-            live_cursor = self.db.game.find(
-                {
-                    **active_game_filter,
-                    "c": {"$ne": True},
-                    "d": {"$gte": today - timedelta(days=1)},
-                }
-            )
-            live_cursor.sort("d", -1)
-            live_loaded, live_skipped = await restore_active_games(
-                live_cursor, corr=False
-            )
-            log.info(
-                "Loaded active live games from db: %s loaded, %s skipped",
-                live_loaded,
-                live_skipped,
-            )
+            with startup.phase("restore active live games"):
+                live_cursor = self.db.game.find(
+                    {
+                        **active_game_filter,
+                        "c": {"$ne": True},
+                        "d": {"$gte": today - timedelta(days=1)},
+                    }
+                )
+                live_cursor.sort("d", -1)
+                live_loaded, live_skipped = await restore_active_games(live_cursor, corr=False)
+                log.info(
+                    "Loaded active live games from db: %s loaded, %s skipped",
+                    live_loaded,
+                    live_skipped,
+                )
 
             async def load_correspondence_games_from_db() -> None:
                 try:
                     corr_cursor = self.db.game.find({**active_game_filter, "c": True})
                     corr_cursor.sort("d", -1)
-                    corr_loaded, corr_skipped = await restore_active_games(
-                        corr_cursor, corr=True
-                    )
+                    corr_loaded, corr_skipped = await restore_active_games(corr_cursor, corr=True)
                     log.info(
                         "Loaded active correspondence games from db: %s loaded, %s skipped",
                         corr_loaded,
@@ -569,107 +565,110 @@ class PychessGlobalAppState:
                 finally:
                     self.correspondence_games_loaded.set()
 
-            await load_active_simuls(self)
+            with startup.phase("restore simuls + static content"):
+                await load_active_simuls(self)
 
-            await upsert_static_docs(self.db.video, VIDEOS)
-            if "ublog_post" not in db_collections:
-                await self.db.create_collection("ublog_post")
-            await self.db.ublog_post.create_index(
-                [("author", 1), ("live", 1), ("publishedAt", -1)]
-            )
-            await self.db.ublog_post.create_index(
-                [("live", 1), ("sticky", -1), ("publishedAt", -1)]
-            )
-            await self.db.ublog_post.create_index(
-                [("live", 1), ("blogType", 1), ("publishedAt", -1)]
-            )
-            await self.db.ublog_post.create_index([("author", 1), ("slug", 1)])
-            await self.db.ublog_post.create_index("legacyBlogId")
-            await self.db.ublog_post.create_index("topics")
-
-            if os.getenv("LEGACY_BLOG_BOOTSTRAP", "1") == "1":
-                # Run legacy bootstrap only for an empty target collection.
-                # This keeps first deploy fully automatic while preventing rewrites
-                # of migrated posts on every subsequent restart.
-                ublog_post_count = await self.db.ublog_post.count_documents({}, limit=1)
-                if ublog_post_count == 0:
-                    from legacy_blog_migration import build_legacy_ublog_docs
-
-                    legacy_blog_author_policy = os.getenv(
-                        "LEGACY_BLOG_AUTHOR_POLICY", "keep"
-                    )
-                    if legacy_blog_author_policy not in ("keep", "official-as-pychess"):
-                        legacy_blog_author_policy = "keep"
-                    await upsert_static_docs(
-                        self.db.ublog_post,
-                        build_legacy_ublog_docs(
-                            author_policy=legacy_blog_author_policy,
-                            strip_preamble=True,
-                        ),
-                    )
-
-            if "fishnet" in db_collections:
-                cursor = self.db.fishnet.find()
-                async for doc in cursor:
-                    FISHNET_KEYS[doc["_id"]] = doc["name"]
-                    self.fishnet_monitor[doc["name"]] = collections.deque([], 50)
-
-            if "config" not in db_collections:
-                await self.db.config.insert_one(
-                    {"name": "logging.config", "value": DEFAULT_LOGGING_CONFIG}
+                await upsert_static_docs(self.db.video, VIDEOS)
+                if "ublog_post" not in db_collections:
+                    await self.db.create_collection("ublog_post")
+                await self.db.ublog_post.create_index(
+                    [("author", 1), ("live", 1), ("publishedAt", -1)]
                 )
-                await self.db.config.create_index("name")
-            await self.db.config.update_one(
-                {"name": CEVAL_AUTO_LOSE_CONFIG_NAME},
-                {"$setOnInsert": {"value": False}},
-                upsert=True,
-            )
+                await self.db.ublog_post.create_index(
+                    [("live", 1), ("sticky", -1), ("publishedAt", -1)]
+                )
+                await self.db.ublog_post.create_index(
+                    [("live", 1), ("blogType", 1), ("publishedAt", -1)]
+                )
+                await self.db.ublog_post.create_index([("author", 1), ("slug", 1)])
+                await self.db.ublog_post.create_index("legacyBlogId")
+                await self.db.ublog_post.create_index("topics")
 
-            if CHEAT_REPORT_COLLECTION not in db_collections:
-                await self.db.create_collection(CHEAT_REPORT_COLLECTION)
-            await self.db[CHEAT_REPORT_COLLECTION].create_index("createdAt")
-            await self.db[CHEAT_REPORT_COLLECTION].create_index("gameId")
-            await self.db[CHEAT_REPORT_COLLECTION].create_index("suspect")
+                if os.getenv("LEGACY_BLOG_BOOTSTRAP", "1") == "1":
+                    # Run legacy bootstrap only for an empty target collection.
+                    # This keeps first deploy fully automatic while preventing rewrites
+                    # of migrated posts on every subsequent restart.
+                    ublog_post_count = await self.db.ublog_post.count_documents({}, limit=1)
+                    if ublog_post_count == 0:
+                        from legacy_blog_migration import build_legacy_ublog_docs
 
-            await self.db.user.update_many(
-                {USERNAME_LOWER_FIELD: {"$exists": False}},
-                [{"$set": {USERNAME_LOWER_FIELD: {"$toLower": "$_id"}}}],
-            )
-            await self.db.user.create_index(
-                USERNAME_LOWER_FIELD,
-                name="username_lower",
-                partialFilterExpression={USERNAME_LOWER_FIELD: {"$type": "string"}},
-            )
+                        legacy_blog_author_policy = os.getenv("LEGACY_BLOG_AUTHOR_POLICY", "keep")
+                        if legacy_blog_author_policy not in ("keep", "official-as-pychess"):
+                            legacy_blog_author_policy = "keep"
+                        await upsert_static_docs(
+                            self.db.ublog_post,
+                            build_legacy_ublog_docs(
+                                author_policy=legacy_blog_author_policy,
+                                strip_preamble=True,
+                            ),
+                        )
 
-            # TODO: remove this after OAuth2 PR deployed !!!
-            userCollectionHasLichessOauth2Fields = await self.db.user.find_one(
-                {
-                    "_id": "Fairy-Stockfish",
-                    "oauth_id": "fairy-stockfish",
-                    "oauth_provider": "lichess",
-                }
-            )
-            if userCollectionHasLichessOauth2Fields is None:
+            with startup.phase("restore fishnet + config + user migrations"):
+                if "fishnet" in db_collections:
+                    cursor = self.db.fishnet.find()
+                    async for doc in cursor:
+                        FISHNET_KEYS[doc["_id"]] = doc["name"]
+                        self.fishnet_monitor[doc["name"]] = collections.deque([], 50)
+
+                if "config" not in db_collections:
+                    await self.db.config.insert_one(
+                        {"name": "logging.config", "value": DEFAULT_LOGGING_CONFIG}
+                    )
+                    await self.db.config.create_index("name")
+                await self.db.config.update_one(
+                    {"name": CEVAL_AUTO_LOSE_CONFIG_NAME},
+                    {"$setOnInsert": {"value": False}},
+                    upsert=True,
+                )
+
+                if CHEAT_REPORT_COLLECTION not in db_collections:
+                    await self.db.create_collection(CHEAT_REPORT_COLLECTION)
+                await self.db[CHEAT_REPORT_COLLECTION].create_index("createdAt")
+                await self.db[CHEAT_REPORT_COLLECTION].create_index("gameId")
+                await self.db[CHEAT_REPORT_COLLECTION].create_index("suspect")
+
                 await self.db.user.update_many(
-                    {},  # Empty filter to select all documents
-                    [
-                        {
-                            "$set": {
-                                "oauth_id": {"$toLower": "$_id"},
-                                "oauth_provider": "lichess",
-                            }
-                        }
-                    ],
+                    {USERNAME_LOWER_FIELD: {"$exists": False}},
+                    [{"$set": {USERNAME_LOWER_FIELD: {"$toLower": "$_id"}}}],
+                )
+                await self.db.user.create_index(
+                    USERNAME_LOWER_FIELD,
+                    name="username_lower",
+                    partialFilterExpression={USERNAME_LOWER_FIELD: {"$type": "string"}},
                 )
 
-            self.create_background_task(
-                load_correspondence_games_from_db(),
-                name="load-correspondence-games",
-            )
+                # TODO: remove this after OAuth2 PR deployed !!!
+                userCollectionHasLichessOauth2Fields = await self.db.user.find_one(
+                    {
+                        "_id": "Fairy-Stockfish",
+                        "oauth_id": "fairy-stockfish",
+                        "oauth_provider": "lichess",
+                    }
+                )
+                if userCollectionHasLichessOauth2Fields is None:
+                    await self.db.user.update_many(
+                        {},  # Empty filter to select all documents
+                        [
+                            {
+                                "$set": {
+                                    "oauth_id": {"$toLower": "$_id"},
+                                    "oauth_provider": "lichess",
+                                }
+                            }
+                        ],
+                    )
+
+            with startup.phase("schedule correspondence restore"):
+                self.create_background_task(
+                    load_correspondence_games_from_db(),
+                    name="load-correspondence-games",
+                )
 
         except Exception:
             log.error("init_from_db() Exception")
             raise
+        finally:
+            startup.log_summary()
 
     def __init_translations(self):
         base = os.path.dirname(__file__)
@@ -689,9 +688,7 @@ class PychessGlobalAppState:
 
             # Create translation class
             try:
-                translation = gettext.translation(
-                    "server", localedir="lang", languages=[lang]
-                )
+                translation = gettext.translation("server", localedir="lang", languages=[lang])
             except FileNotFoundError:
                 log.warning("Missing translations file for lang %s", lang)
                 translation = gettext.NullTranslations()
@@ -707,19 +704,13 @@ class PychessGlobalAppState:
                     or variant in SEATURDAY
                     or variant in PAUSED_MONTHLY_VARIANTS
                 ):
-                    tname = translated_tournament_name(
-                        variant, MONTHLY, ARENA, translation
-                    )
+                    tname = translated_tournament_name(variant, MONTHLY, ARENA, translation)
                     self.tourneynames[lang][(variant, MONTHLY, ARENA)] = tname
                 if variant in SEATURDAY or variant in WEEKLY_VARIANTS:
-                    tname = translated_tournament_name(
-                        variant, WEEKLY, ARENA, translation
-                    )
+                    tname = translated_tournament_name(variant, WEEKLY, ARENA, translation)
                     self.tourneynames[lang][(variant, WEEKLY, ARENA)] = tname
                 if variant in SHIELDS:
-                    tname = translated_tournament_name(
-                        variant, SHIELD, ARENA, translation
-                    )
+                    tname = translated_tournament_name(variant, SHIELD, ARENA, translation)
                     self.tourneynames[lang][(variant, SHIELD, ARENA)] = tname
 
         # https://github.com/aio-libs/aiohttp-jinja2/issues/187#issuecomment-2519831516
@@ -868,11 +859,7 @@ class PychessGlobalAppState:
                 if removed is None:
                     # The queue may already be gone when cleanup runs after
                     # reconnect/disconnect races or repeated cache removals.
-                    log.debug(
-                        "%s already missing from %s.game_queues",
-                        game.id,
-                        player.username,
-                    )
+                    log.debug("%s already missing from %s.game_queues", game.id, player.username)
 
         for player in game.all_players:
             if player.game_in_progress == game.id:
@@ -899,9 +886,7 @@ class PychessGlobalAppState:
         self.game_remove_tasks.pop(game.id, None)
         await self._evict_game_from_cache(game)
 
-    async def maybe_remove_finished_game_from_cache_now(
-        self, game: Game | GameBug
-    ) -> None:
+    async def maybe_remove_finished_game_from_cache_now(self, game: Game | GameBug) -> None:
         if game.status <= STARTED or game.id not in self.games:
             return
 
@@ -910,15 +895,10 @@ class PychessGlobalAppState:
         if has_pending_analysis_work_for_game(self, game.id):
             return
 
-        if any(
-            player.is_user_active_in_game(game.id) for player in game.non_bot_players
-        ):
+        if any(player.is_user_active_in_game(game.id) for player in game.non_bot_players):
             return
 
-        if any(
-            spectator.is_user_active_in_game(game.id)
-            for spectator in tuple(game.spectators)
-        ):
+        if any(spectator.is_user_active_in_game(game.id) for spectator in tuple(game.spectators)):
             return
 
         await self.remove_game_from_cache_now(game)
@@ -938,9 +918,7 @@ class PychessGlobalAppState:
         return result
 
     async def remove_from_cache(self, game):
-        await asyncio.sleep(
-            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME
-        )
+        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME)
         await self._evict_game_from_cache(game)
 
     def schedule_tournament_cache_removal(self, tournament: Tournament):
@@ -963,9 +941,7 @@ class PychessGlobalAppState:
         task.add_done_callback(_cleanup_task)
 
     async def remove_tournament_from_cache(self, tournament_id: str):
-        await asyncio.sleep(
-            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME
-        )
+        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME)
 
         tournament = self.tournaments.get(tournament_id)
         if tournament is None or tournament.status <= T_STARTED:
@@ -1139,9 +1115,7 @@ class PychessGlobalAppState:
         return sum((1 for user in self.users.values() if user.online))
 
     def auto_pairing_count(self):
-        return sum(
-            (1 for user in self.auto_pairing_users if user.ready_for_auto_pairing)
-        )
+        return sum((1 for user in self.auto_pairing_users if user.ready_for_auto_pairing))
 
     def __str__(self):
         return self.__stringify(str)


### PR DESCRIPTION
`challenge_accept()` had a critical bug: `asyncio.sleep(1)` was called
without `await`, so the loop never yielded. The SSE channel notification
was silently dropped whenever the channel wasn't ready yet, leaving the
challenger unaware that their invite was accepted.

`challenge_decline()` had the correct `await` but still busy-polled for
up to 10 seconds, blocking the event loop.

Fix: added `invite_events: dict[str, asyncio.Event]` to app state.
`subscribe_invites()` signals the event as soon as the SSE channel is
registered. `challenge_accept/decline` wait on the event via
`asyncio.wait_for(..., timeout=10.0)` — zero polling, instant wakeup.

Both functions now use `.get()` instead of direct dict access to avoid
`KeyError` if the channel is still absent after timeout.
