### PR TITLE
fix: replace busy-wait in challenge_accept/decline with asyncio.Event

### DIFF
--- a/server/bot_api.py
+++ b/server/bot_api.py
@@ -94,18 +94,21 @@ async def challenge_accept(request: web.Request) -> web.StreamResponse:
     result: NewGameMessage | ErrorMessage = await new_game(app_state, seek, gameId)  # noqa: F821
 
     if result["type"] == "new_game":
-        # TODO: use asyncio.Event()
-        wait_count = 0
-        while gameId not in app_state.invite_channels and wait_count < 10:
-            asyncio.sleep(1)  # type: ignore[unused-coroutine]
-            wait_count += 1
-            log.debug("BOT_API challenge_accept() WAITING FOR SSE: %s", wait_count)
+        if gameId not in app_state.invite_channels:
+            event = app_state.invite_events.setdefault(gameId, asyncio.Event())
+            try:
+                await asyncio.wait_for(event.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                log.warning("BOT_API challenge_accept() SSE timeout for %s", gameId)
+            finally:
+                app_state.invite_events.pop(gameId, None)
 
         try:
             # Put response data to sse subscriber queue
-            channels = app_state.invite_channels[gameId]
-            for queue in channels:
-                await queue.put(json_dumps({"gameId": gameId, "accept": True}))
+            channels = app_state.invite_channels.get(gameId)
+            if channels is not None:
+                for queue in channels:
+                    await queue.put(json_dumps({"gameId": gameId, "accept": True}))
         except ConnectionResetError:
             log.error("/api/challenge/{%s}/accept ConnectionResetError", gameId)
 
@@ -129,18 +132,21 @@ async def challenge_decline(request: web.Request) -> web.StreamResponse:
     if TYPE_CHECKING:
         assert gameId is not None
 
-    # TODO: use asyncio.Event()
-    wait_count = 0
-    while gameId not in app_state.invite_channels and wait_count < 10:
-        await asyncio.sleep(1)
-        wait_count += 1
-        log.debug("BOT_API challenge_decline() WAITING FOR SSE: %s", wait_count)
+    if gameId not in app_state.invite_channels:
+        event = app_state.invite_events.setdefault(gameId, asyncio.Event())
+        try:
+            await asyncio.wait_for(event.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            log.warning("BOT_API challenge_decline() SSE timeout for %s", gameId)
+        finally:
+            app_state.invite_events.pop(gameId, None)
 
     try:
         # Put response data to sse subscriber queue
-        channels = app_state.invite_channels[gameId]
-        for queue in channels:
-            await queue.put(json_dumps({"gameId": gameId, "accept": False}))
+        channels = app_state.invite_channels.get(gameId)
+        if channels is not None:
+            for queue in channels:
+                await queue.put(json_dumps({"gameId": gameId, "accept": False}))
     except ConnectionResetError:
         log.error("/api/challenge/{%s}/decline ConnectionResetError", gameId)
 

--- a/server/game_api.py
+++ b/server/game_api.py
@@ -13,7 +13,16 @@ from pymongo.errors import BulkWriteError
 from aiohttp_swagger3 import swagger_doc
 
 from compress import C2R, decode_move_standard
-from const import DARK_FEN, STARTED, MATE, INVALIDMOVE, VARIANTEND, CLAIM, SSE_GET_TIMEOUT, SWISS
+from const import (
+    DARK_FEN,
+    STARTED,
+    MATE,
+    INVALIDMOVE,
+    VARIANTEND,
+    CLAIM,
+    SSE_GET_TIMEOUT,
+    SWISS,
+)
 from convert import zero2grand
 from settings import ADMINS
 from tournament.tournaments import get_tournament_name, load_tournament
@@ -186,7 +195,9 @@ def variant_counts_from_docs(
         except KeyError:
             if variant not in _seen_discontinued_variants:
                 _seen_discontinued_variants.add(variant)
-                log.info("Ignoring discontinued variant %s in historical stats", variant)
+                log.info(
+                    "Ignoring discontinued variant %s in historical stats", variant
+                )
 
 
 async def get_variant_stats(request: web.Request) -> web.StreamResponse:
@@ -229,7 +240,9 @@ async def get_variant_stats(request: web.Request) -> web.StreamResponse:
             docs = await variant_counts_aggregation(app_state, humans)
             variant_counts_from_docs(variant_counts, docs)
 
-        series = [{"name": variant, "data": variant_counts[variant]} for variant in VARIANTS]
+        series = [
+            {"name": variant, "data": variant_counts[variant]} for variant in VARIANTS
+        ]
 
         stats[cur_period] = series
 
@@ -283,7 +296,9 @@ def _parse_positive_int_query_param(request: web.Request, name: str) -> int | No
             text=f"Query parameter '{name}' must be a positive integer."
         ) from error
     if value <= 0:
-        raise web.HTTPBadRequest(text=f"Query parameter '{name}' must be a positive integer.")
+        raise web.HTTPBadRequest(
+            text=f"Query parameter '{name}' must be a positive integer."
+        )
     return value
 
 
@@ -330,9 +345,16 @@ def _build_user_games_filter_cond(
     elif selected_filter == "loss":
         if level is not None:
             filter_cond["$and"] = [
-                {"$or": [{"r": "a", "us.1": profile_id}, {"r": "b", "us.0": profile_id}]},
+                {
+                    "$or": [
+                        {"r": "a", "us.1": profile_id},
+                        {"r": "b", "us.0": profile_id},
+                    ]
+                },
                 {"x": int(level)},
-                {"$or": [{"if": None}, {"v": "j"}]},  # Janggi games always have initial FEN!
+                {
+                    "$or": [{"if": None}, {"v": "j"}]
+                },  # Janggi games always have initial FEN!
                 {
                     "$or": [
                         {"s": MATE},
@@ -348,7 +370,10 @@ def _build_user_games_filter_cond(
                 {"r": "b", "us.0": profile_id},
             ]
     elif selected_filter == "rated":
-        filter_cond["$or"] = [{"y": 1, "us.1": profile_id}, {"y": 1, "us.0": profile_id}]
+        filter_cond["$or"] = [
+            {"y": 1, "us.1": profile_id},
+            {"y": 1, "us.0": profile_id},
+        ]
     elif selected_filter == "playing":
         filter_cond["$and"] = [
             {"$or": [{"c": True, "us.1": profile_id}, {"c": True, "us.0": profile_id}]},
@@ -423,7 +448,9 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
     if TYPE_CHECKING:
         assert profileId is not None
 
-    selected_filter, selected_variant, path_parts = _resolve_user_games_filter_and_variant(request)
+    selected_filter, selected_variant, path_parts = (
+        _resolve_user_games_filter_and_variant(request)
+    )
 
     # print("URL", request.rel_url)
     level = request.rel_url.query.get("x")
@@ -455,7 +482,9 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
             if latest_games is not None:
                 cursor.limit(latest_games)
         else:
-            cursor.sort("d", -1).skip(int(page_num) * GAME_PAGE_SIZE).limit(GAME_PAGE_SIZE)
+            cursor.sort("d", -1).skip(int(page_num) * GAME_PAGE_SIZE).limit(
+                GAME_PAGE_SIZE
+            )
         doc: GameDoc
         async for doc in cursor:
             try:
@@ -467,25 +496,41 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
 
             doc["r"] = C2R[doc["r"]]
             doc["wt"] = (
-                app_state.users[doc["us"][0]].title if doc["us"][0] in app_state.users else ""
+                app_state.users[doc["us"][0]].title
+                if doc["us"][0] in app_state.users
+                else ""
             )
             doc["bt"] = (
-                app_state.users[doc["us"][1]].title if doc["us"][1] in app_state.users else ""
+                app_state.users[doc["us"][1]].title
+                if doc["us"][1] in app_state.users
+                else ""
             )
 
             if len(doc["us"]) > 2:
                 doc["wtB"] = (
-                    app_state.users[doc["us"][2]].title if doc["us"][2] in app_state.users else ""
+                    app_state.users[doc["us"][2]].title
+                    if doc["us"][2] in app_state.users
+                    else ""
                 )
                 doc["btB"] = (
-                    app_state.users[doc["us"][3]].title if doc["us"][3] in app_state.users else ""
+                    app_state.users[doc["us"][3]].title
+                    if doc["us"][3] in app_state.users
+                    else ""
                 )
 
             server_variant = get_server_variant(variant, bool(doc.get("z", 0)))
             decode_method = server_variant.move_decoding
             if server_variant.two_boards:
-                mA = [m for idx, m in enumerate(doc["m"]) if "o" in doc and doc["o"][idx] == 0]
-                mB = [m for idx, m in enumerate(doc["m"]) if "o" in doc and doc["o"][idx] == 1]
+                mA = [
+                    m
+                    for idx, m in enumerate(doc["m"])
+                    if "o" in doc and doc["o"][idx] == 0
+                ]
+                mB = [
+                    m
+                    for idx, m in enumerate(doc["m"])
+                    if "o" in doc and doc["o"][idx] == 1
+                ]
                 doc["lm"] = decode_move_standard(mA[-1]) if len(mA) > 0 else ""
                 doc["lmB"] = decode_move_standard(mB[-1]) if len(mB) > 0 else ""
             else:
@@ -550,12 +595,19 @@ async def subscribe_invites(request: web.Request) -> web.StreamResponse:
         app_state.invite_channels[gameId] = set()
     app_state.invite_channels[gameId].add(queue)
 
+    # Signal challenge_accept/decline that the SSE channel is now ready.
+    event = app_state.invite_events.get(gameId)
+    if event is not None:
+        event.set()
+
     response: web.StreamResponse = web.Response(status=200)
     try:
         async with sse_response(request) as response:
             while response.is_connected():
                 try:
-                    payload = await asyncio.wait_for(queue.get(), timeout=SSE_GET_TIMEOUT)
+                    payload = await asyncio.wait_for(
+                        queue.get(), timeout=SSE_GET_TIMEOUT
+                    )
                     await response.send(payload)
                     queue.task_done()
                 except asyncio.TimeoutError:
@@ -581,7 +633,9 @@ async def subscribe_games(request: web.Request) -> web.StreamResponse:
         async with sse_response(request) as response:
             while response.is_connected():
                 try:
-                    payload = await asyncio.wait_for(queue.get(), timeout=SSE_GET_TIMEOUT)
+                    payload = await asyncio.wait_for(
+                        queue.get(), timeout=SSE_GET_TIMEOUT
+                    )
                     await response.send(payload)
                     queue.task_done()
                 except asyncio.TimeoutError:
@@ -634,9 +688,14 @@ async def _get_games(request: web.Request) -> web.StreamResponse:
             }
             for game in games
             if game.status == STARTED
-            and ((game.variant == variant and game.chess960 == chess960) if variant else True)
             and (
-                (f"{game.variant}960" if game.chess960 else game.variant) in allowed_variants
+                (game.variant == variant and game.chess960 == chess960)
+                if variant
+                else True
+            )
+            and (
+                (f"{game.variant}960" if game.chess960 else game.variant)
+                in allowed_variants
                 if allowed_variants is not None
                 else True
             )
@@ -680,7 +739,8 @@ async def _stream_pgn_cursor(
                 failed += 1
                 if len(failed_games) < EXPORT_FAILED_SAMPLE_LIMIT:
                     failed_games.append(
-                        "%s %s %s" % (doc["_id"], C2V[doc["v"]], doc["d"].strftime("%Y.%m.%d"))
+                        "%s %s %s"
+                        % (doc["_id"], C2V[doc["v"]], doc["d"].strftime("%Y.%m.%d"))
                     )
                 continue
         log.info("failed/all: %s/%s", failed, game_counter)
@@ -719,7 +779,9 @@ async def export_user_pgn(request: web.Request) -> web.StreamResponse:
     if session_user != profileId and session_user not in ADMINS:
         raise web.HTTPForbidden(text="Users can only export their own games.")
 
-    selected_filter, selected_variant, _path_parts = _resolve_user_games_filter_and_variant(request)
+    selected_filter, selected_variant, _path_parts = (
+        _resolve_user_games_filter_and_variant(request)
+    )
     level = request.rel_url.query.get("x")
     filter_cond = _build_user_games_filter_cond(
         profile_id=profileId,
@@ -775,7 +837,9 @@ async def export_monthly_pgn(request: web.Request) -> web.StreamResponse:
     log.debug("yearmonth: %r %r", yearmonth[:4], yearmonth[4:])
     filter_cond = {
         "$and": [
-            {"$expr": {"s": {"$gt": STARTED}}},  # prevent leaking ongoing fogofwar game info
+            {
+                "$expr": {"s": {"$gt": STARTED}}
+            },  # prevent leaking ongoing fogofwar game info
             {"$expr": {"$eq": [{"$year": "$d"}, int(yearmonth[:4])]}},
             {"$expr": {"$eq": [{"$month": "$d"}, int(yearmonth[4:])]}},
         ]

--- a/server/game_api.py
+++ b/server/game_api.py
@@ -13,16 +13,7 @@ from pymongo.errors import BulkWriteError
 from aiohttp_swagger3 import swagger_doc
 
 from compress import C2R, decode_move_standard
-from const import (
-    DARK_FEN,
-    STARTED,
-    MATE,
-    INVALIDMOVE,
-    VARIANTEND,
-    CLAIM,
-    SSE_GET_TIMEOUT,
-    SWISS,
-)
+from const import DARK_FEN, STARTED, MATE, INVALIDMOVE, VARIANTEND, CLAIM, SSE_GET_TIMEOUT, SWISS
 from convert import zero2grand
 from settings import ADMINS
 from tournament.tournaments import get_tournament_name, load_tournament
@@ -195,9 +186,7 @@ def variant_counts_from_docs(
         except KeyError:
             if variant not in _seen_discontinued_variants:
                 _seen_discontinued_variants.add(variant)
-                log.info(
-                    "Ignoring discontinued variant %s in historical stats", variant
-                )
+                log.info("Ignoring discontinued variant %s in historical stats", variant)
 
 
 async def get_variant_stats(request: web.Request) -> web.StreamResponse:
@@ -240,9 +229,7 @@ async def get_variant_stats(request: web.Request) -> web.StreamResponse:
             docs = await variant_counts_aggregation(app_state, humans)
             variant_counts_from_docs(variant_counts, docs)
 
-        series = [
-            {"name": variant, "data": variant_counts[variant]} for variant in VARIANTS
-        ]
+        series = [{"name": variant, "data": variant_counts[variant]} for variant in VARIANTS]
 
         stats[cur_period] = series
 
@@ -296,9 +283,7 @@ def _parse_positive_int_query_param(request: web.Request, name: str) -> int | No
             text=f"Query parameter '{name}' must be a positive integer."
         ) from error
     if value <= 0:
-        raise web.HTTPBadRequest(
-            text=f"Query parameter '{name}' must be a positive integer."
-        )
+        raise web.HTTPBadRequest(text=f"Query parameter '{name}' must be a positive integer.")
     return value
 
 
@@ -345,16 +330,9 @@ def _build_user_games_filter_cond(
     elif selected_filter == "loss":
         if level is not None:
             filter_cond["$and"] = [
-                {
-                    "$or": [
-                        {"r": "a", "us.1": profile_id},
-                        {"r": "b", "us.0": profile_id},
-                    ]
-                },
+                {"$or": [{"r": "a", "us.1": profile_id}, {"r": "b", "us.0": profile_id}]},
                 {"x": int(level)},
-                {
-                    "$or": [{"if": None}, {"v": "j"}]
-                },  # Janggi games always have initial FEN!
+                {"$or": [{"if": None}, {"v": "j"}]},  # Janggi games always have initial FEN!
                 {
                     "$or": [
                         {"s": MATE},
@@ -370,10 +348,7 @@ def _build_user_games_filter_cond(
                 {"r": "b", "us.0": profile_id},
             ]
     elif selected_filter == "rated":
-        filter_cond["$or"] = [
-            {"y": 1, "us.1": profile_id},
-            {"y": 1, "us.0": profile_id},
-        ]
+        filter_cond["$or"] = [{"y": 1, "us.1": profile_id}, {"y": 1, "us.0": profile_id}]
     elif selected_filter == "playing":
         filter_cond["$and"] = [
             {"$or": [{"c": True, "us.1": profile_id}, {"c": True, "us.0": profile_id}]},
@@ -448,9 +423,7 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
     if TYPE_CHECKING:
         assert profileId is not None
 
-    selected_filter, selected_variant, path_parts = (
-        _resolve_user_games_filter_and_variant(request)
-    )
+    selected_filter, selected_variant, path_parts = _resolve_user_games_filter_and_variant(request)
 
     # print("URL", request.rel_url)
     level = request.rel_url.query.get("x")
@@ -482,9 +455,7 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
             if latest_games is not None:
                 cursor.limit(latest_games)
         else:
-            cursor.sort("d", -1).skip(int(page_num) * GAME_PAGE_SIZE).limit(
-                GAME_PAGE_SIZE
-            )
+            cursor.sort("d", -1).skip(int(page_num) * GAME_PAGE_SIZE).limit(GAME_PAGE_SIZE)
         doc: GameDoc
         async for doc in cursor:
             try:
@@ -496,41 +467,25 @@ async def get_user_games(request: web.Request) -> web.StreamResponse:
 
             doc["r"] = C2R[doc["r"]]
             doc["wt"] = (
-                app_state.users[doc["us"][0]].title
-                if doc["us"][0] in app_state.users
-                else ""
+                app_state.users[doc["us"][0]].title if doc["us"][0] in app_state.users else ""
             )
             doc["bt"] = (
-                app_state.users[doc["us"][1]].title
-                if doc["us"][1] in app_state.users
-                else ""
+                app_state.users[doc["us"][1]].title if doc["us"][1] in app_state.users else ""
             )
 
             if len(doc["us"]) > 2:
                 doc["wtB"] = (
-                    app_state.users[doc["us"][2]].title
-                    if doc["us"][2] in app_state.users
-                    else ""
+                    app_state.users[doc["us"][2]].title if doc["us"][2] in app_state.users else ""
                 )
                 doc["btB"] = (
-                    app_state.users[doc["us"][3]].title
-                    if doc["us"][3] in app_state.users
-                    else ""
+                    app_state.users[doc["us"][3]].title if doc["us"][3] in app_state.users else ""
                 )
 
             server_variant = get_server_variant(variant, bool(doc.get("z", 0)))
             decode_method = server_variant.move_decoding
             if server_variant.two_boards:
-                mA = [
-                    m
-                    for idx, m in enumerate(doc["m"])
-                    if "o" in doc and doc["o"][idx] == 0
-                ]
-                mB = [
-                    m
-                    for idx, m in enumerate(doc["m"])
-                    if "o" in doc and doc["o"][idx] == 1
-                ]
+                mA = [m for idx, m in enumerate(doc["m"]) if "o" in doc and doc["o"][idx] == 0]
+                mB = [m for idx, m in enumerate(doc["m"]) if "o" in doc and doc["o"][idx] == 1]
                 doc["lm"] = decode_move_standard(mA[-1]) if len(mA) > 0 else ""
                 doc["lmB"] = decode_move_standard(mB[-1]) if len(mB) > 0 else ""
             else:
@@ -605,9 +560,7 @@ async def subscribe_invites(request: web.Request) -> web.StreamResponse:
         async with sse_response(request) as response:
             while response.is_connected():
                 try:
-                    payload = await asyncio.wait_for(
-                        queue.get(), timeout=SSE_GET_TIMEOUT
-                    )
+                    payload = await asyncio.wait_for(queue.get(), timeout=SSE_GET_TIMEOUT)
                     await response.send(payload)
                     queue.task_done()
                 except asyncio.TimeoutError:
@@ -633,9 +586,7 @@ async def subscribe_games(request: web.Request) -> web.StreamResponse:
         async with sse_response(request) as response:
             while response.is_connected():
                 try:
-                    payload = await asyncio.wait_for(
-                        queue.get(), timeout=SSE_GET_TIMEOUT
-                    )
+                    payload = await asyncio.wait_for(queue.get(), timeout=SSE_GET_TIMEOUT)
                     await response.send(payload)
                     queue.task_done()
                 except asyncio.TimeoutError:
@@ -688,14 +639,9 @@ async def _get_games(request: web.Request) -> web.StreamResponse:
             }
             for game in games
             if game.status == STARTED
+            and ((game.variant == variant and game.chess960 == chess960) if variant else True)
             and (
-                (game.variant == variant and game.chess960 == chess960)
-                if variant
-                else True
-            )
-            and (
-                (f"{game.variant}960" if game.chess960 else game.variant)
-                in allowed_variants
+                (f"{game.variant}960" if game.chess960 else game.variant) in allowed_variants
                 if allowed_variants is not None
                 else True
             )
@@ -739,8 +685,7 @@ async def _stream_pgn_cursor(
                 failed += 1
                 if len(failed_games) < EXPORT_FAILED_SAMPLE_LIMIT:
                     failed_games.append(
-                        "%s %s %s"
-                        % (doc["_id"], C2V[doc["v"]], doc["d"].strftime("%Y.%m.%d"))
+                        "%s %s %s" % (doc["_id"], C2V[doc["v"]], doc["d"].strftime("%Y.%m.%d"))
                     )
                 continue
         log.info("failed/all: %s/%s", failed, game_counter)
@@ -779,9 +724,7 @@ async def export_user_pgn(request: web.Request) -> web.StreamResponse:
     if session_user != profileId and session_user not in ADMINS:
         raise web.HTTPForbidden(text="Users can only export their own games.")
 
-    selected_filter, selected_variant, _path_parts = (
-        _resolve_user_games_filter_and_variant(request)
-    )
+    selected_filter, selected_variant, _path_parts = _resolve_user_games_filter_and_variant(request)
     level = request.rel_url.query.get("x")
     filter_cond = _build_user_games_filter_cond(
         profile_id=profileId,
@@ -837,9 +780,7 @@ async def export_monthly_pgn(request: web.Request) -> web.StreamResponse:
     log.debug("yearmonth: %r %r", yearmonth[:4], yearmonth[4:])
     filter_cond = {
         "$and": [
-            {
-                "$expr": {"s": {"$gt": STARTED}}
-            },  # prevent leaking ongoing fogofwar game info
+            {"$expr": {"s": {"$gt": STARTED}}},  # prevent leaking ongoing fogofwar game info
             {"$expr": {"$eq": [{"$year": "$d"}, int(yearmonth[:4])]}},
             {"$expr": {"$eq": [{"$month": "$d"}, int(yearmonth[4:])]}},
         ]

--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -106,13 +106,17 @@ from startup_timer import StartupTimer
 log = logging.getLogger(__name__)
 
 GAME_KEEP_TIME = 1800  # keep game in app[games_key] for GAME_KEEP_TIME secs
-TOURNAMENT_KEEP_TIME = 1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
+TOURNAMENT_KEEP_TIME = (
+    1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
+)
 T = TypeVar("T")
 USERNAME_LOWER_FIELD = "username_lower"
 
 
 def _is_test_run() -> bool:
-    return any("pytest" in arg for arg in sys.argv) or any("unittest" in arg for arg in sys.argv)
+    return any("pytest" in arg for arg in sys.argv) or any(
+        "unittest" in arg for arg in sys.argv
+    )
 
 
 # Local test cache retention; keep this small for test runs, but use the
@@ -145,7 +149,9 @@ class PychessGlobalAppState:
             self.lobby = Lobby(self)
             self.chat_flood = ChatFlood()
             # one dict per tournament! {tournamentId: {user.username: user.tournament_sockets, ...}, ...}
-            self.tourneysockets: dict[str, dict[str, set[WebSocketResponse | None]]] = {}
+            self.tourneysockets: dict[
+                str, dict[str, set[WebSocketResponse | None]]
+            ] = {}
             self.background_tasks: set[asyncio.Task[Any]] = set()
             self.game_remove_tasks: dict[str, asyncio.Task[None]] = {}
             self.tournament_remove_tasks: dict[str, asyncio.Task[None]] = {}
@@ -169,7 +175,13 @@ class PychessGlobalAppState:
             self.invites: dict[str, Seek] = {}
             self.game_channels: Set[asyncio.Queue[str]] = set()
             self.invite_channels: dict[str, Set[asyncio.Queue[str]]] = {}
-            self.highscore = {variant: ValueSortedDict(neg) for variant in RATED_VARIANTS}
+            # Signalled by subscribe_invites() as soon as the SSE channel for a
+            # given gameId is ready. challenge_accept/decline wait on this instead
+            # of busy-polling invite_channels.
+            self.invite_events: dict[str, asyncio.Event] = {}
+            self.highscore = {
+                variant: ValueSortedDict(neg) for variant in RATED_VARIANTS
+            }
             self.lobby_leaderboard: list["LobbyLeaderboardEntry"] = []
             self.lobby_tournament_winners: list["TournamentWinnerEntry"] = []
             self.shield = {}
@@ -224,14 +236,18 @@ class PychessGlobalAppState:
             self.started_at = datetime.now(timezone.utc)
             self.push_notifier = PushNotifier(self)
             if self.push_notifier.enabled:
-                self.create_background_task(self.push_notifier.run(), name="push-notifier")
+                self.create_background_task(
+                    self.push_notifier.run(), name="push-notifier"
+                )
 
         startup.log_summary()
 
     async def init_from_db(self):
         startup = StartupTimer(log, "PychessGlobalAppState.init_from_db")
         if self.db is None:
-            log.debug("[startup] PychessGlobalAppState.init_from_db skipped: no database")
+            log.debug(
+                "[startup] PychessGlobalAppState.init_from_db skipped: no database"
+            )
             startup.log_summary()
             return
 
@@ -241,7 +257,9 @@ class PychessGlobalAppState:
                 if doc_id is None:
                     continue
                 update = {key: value for key, value in doc.items() if key != "_id"}
-                await collection.update_one({"_id": doc_id}, {"$set": update}, upsert=True)
+                await collection.update_one(
+                    {"_id": doc_id}, {"$set": update}, upsert=True
+                )
 
         # Read tournaments, users and highscore from db
         try:
@@ -249,7 +267,9 @@ class PychessGlobalAppState:
                 db_collections = await self.db.list_collection_names()
 
                 puzzle = await self.db.puzzle.find_one()
-                puzzle_doc_rename_needed = (puzzle is not None) and ("variant" in puzzle)
+                puzzle_doc_rename_needed = (puzzle is not None) and (
+                    "variant" in puzzle
+                )
                 if puzzle_doc_rename_needed:
                     await rename_puzzle_fields(self.db)
 
@@ -271,7 +291,9 @@ class PychessGlobalAppState:
                     {"$or": [{"status": T_STARTED}, {"status": T_CREATED}]}
                 )
                 cursor.sort("startsAt", -1)
-                to_date = (datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)).date()
+                to_date = (
+                    datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)
+                ).date()
                 async for doc in cursor:
                     if doc["status"] == T_STARTED or (
                         doc["status"] == T_CREATED and doc["startsAt"].date() <= to_date
@@ -285,7 +307,9 @@ class PychessGlobalAppState:
                 await create_scheduled_tournaments(self, new_tournaments_data)
 
             with startup.phase("restore highscore + lobby caches"):
-                self.create_background_task(generate_shield(self), name="generate-shield")
+                self.create_background_task(
+                    generate_shield(self), name="generate-shield"
+                )
 
                 if "highscore" not in db_collections:
                     await generate_highscore(self)
@@ -314,7 +338,9 @@ class PychessGlobalAppState:
                 else:
                     cursor = self.db.dailypuzzle.find()
                     docs = await cursor.to_list(length=365 * len(GAME_CATEGORIES))
-                    self.daily_puzzle_ids = {doc["_id"]: doc["puzzleId"] for doc in docs}
+                    self.daily_puzzle_ids = {
+                        doc["_id"]: doc["puzzleId"] for doc in docs
+                    }
 
                 if "lobbychat" not in db_collections:
                     try:
@@ -344,9 +370,15 @@ class PychessGlobalAppState:
                 await self.db.game.create_index("by")
                 await self.db.game.create_index("c")
                 await self.db.game.create_index("tid")
-                await self.db.game.create_index([("us", 1), ("d", -1)], name="us_d_desc")
-                await self.db.game.create_index([("us.0", 1), ("d", -1)], name="us0_d_desc")
-                await self.db.game.create_index([("us.1", 1), ("d", -1)], name="us1_d_desc")
+                await self.db.game.create_index(
+                    [("us", 1), ("d", -1)], name="us_d_desc"
+                )
+                await self.db.game.create_index(
+                    [("us.0", 1), ("d", -1)], name="us0_d_desc"
+                )
+                await self.db.game.create_index(
+                    [("us.1", 1), ("d", -1)], name="us1_d_desc"
+                )
                 await self.db.game.create_index(
                     [("us.0", 1), ("us.1", 1), ("d", -1)],
                     name="us0_us1_d_desc",
@@ -393,8 +425,12 @@ class PychessGlobalAppState:
 
                 if "forum_post" not in db_collections:
                     await self.db.create_collection("forum_post")
-                await self.db.forum_post.create_index([("topicId", 1), ("createdAt", 1)])
-                await self.db.forum_post.create_index([("categId", 1), ("createdAt", -1)])
+                await self.db.forum_post.create_index(
+                    [("topicId", 1), ("createdAt", 1)]
+                )
+                await self.db.forum_post.create_index(
+                    [("categId", 1), ("createdAt", -1)]
+                )
                 await self.db.forum_post.create_index([("text", "text")])
 
                 if "user_report" not in db_collections:
@@ -410,7 +446,9 @@ class PychessGlobalAppState:
 
                 if "security_ban_signal" not in db_collections:
                     await self.db.create_collection("security_ban_signal")
-                await self.db.security_ban_signal.create_index("expireAt", expireAfterSeconds=0)
+                await self.db.security_ban_signal.create_index(
+                    "expireAt", expireAfterSeconds=0
+                )
 
             with startup.phase("restore autopairings + seeks"):
                 # Load auto pairings from database
@@ -452,7 +490,10 @@ class PychessGlobalAppState:
                             challenge_decline_reason=doc.get("challengeDeclineReason"),
                         )
                         if not should_restore_persisted_seek(seek):
-                            log.debug("Skipping non-restorable seek from database: %s", seek.id)
+                            log.debug(
+                                "Skipping non-restorable seek from database: %s",
+                                seek.id,
+                            )
                             continue
                         log.debug("Loading seek from database: %s" % seek)
                         self.seeks[seek.id] = seek
@@ -512,7 +553,9 @@ class PychessGlobalAppState:
                 async for doc in cursor:
                     if corr:
                         # Don't load old never-started correspondence games.
-                        if doc["s"] == -2 and doc["d"] < today - timedelta(days=doc.get("b", 1)):
+                        if doc["s"] == -2 and doc["d"] < today - timedelta(
+                            days=doc.get("b", 1)
+                        ):
                             skipped += 1
                             continue
                     else:
@@ -540,7 +583,9 @@ class PychessGlobalAppState:
                     }
                 )
                 live_cursor.sort("d", -1)
-                live_loaded, live_skipped = await restore_active_games(live_cursor, corr=False)
+                live_loaded, live_skipped = await restore_active_games(
+                    live_cursor, corr=False
+                )
                 log.info(
                     "Loaded active live games from db: %s loaded, %s skipped",
                     live_loaded,
@@ -551,7 +596,9 @@ class PychessGlobalAppState:
                 try:
                     corr_cursor = self.db.game.find({**active_game_filter, "c": True})
                     corr_cursor.sort("d", -1)
-                    corr_loaded, corr_skipped = await restore_active_games(corr_cursor, corr=True)
+                    corr_loaded, corr_skipped = await restore_active_games(
+                        corr_cursor, corr=True
+                    )
                     log.info(
                         "Loaded active correspondence games from db: %s loaded, %s skipped",
                         corr_loaded,
@@ -585,12 +632,19 @@ class PychessGlobalAppState:
                     # Run legacy bootstrap only for an empty target collection.
                     # This keeps first deploy fully automatic while preventing rewrites
                     # of migrated posts on every subsequent restart.
-                    ublog_post_count = await self.db.ublog_post.count_documents({}, limit=1)
+                    ublog_post_count = await self.db.ublog_post.count_documents(
+                        {}, limit=1
+                    )
                     if ublog_post_count == 0:
                         from legacy_blog_migration import build_legacy_ublog_docs
 
-                        legacy_blog_author_policy = os.getenv("LEGACY_BLOG_AUTHOR_POLICY", "keep")
-                        if legacy_blog_author_policy not in ("keep", "official-as-pychess"):
+                        legacy_blog_author_policy = os.getenv(
+                            "LEGACY_BLOG_AUTHOR_POLICY", "keep"
+                        )
+                        if legacy_blog_author_policy not in (
+                            "keep",
+                            "official-as-pychess",
+                        ):
                             legacy_blog_author_policy = "keep"
                         await upsert_static_docs(
                             self.db.ublog_post,
@@ -685,7 +739,9 @@ class PychessGlobalAppState:
 
             # Create translation class
             try:
-                translation = gettext.translation("server", localedir="lang", languages=[lang])
+                translation = gettext.translation(
+                    "server", localedir="lang", languages=[lang]
+                )
             except FileNotFoundError:
                 log.warning("Missing translations file for lang %s", lang)
                 translation = gettext.NullTranslations()
@@ -701,13 +757,19 @@ class PychessGlobalAppState:
                     or variant in SEATURDAY
                     or variant in PAUSED_MONTHLY_VARIANTS
                 ):
-                    tname = translated_tournament_name(variant, MONTHLY, ARENA, translation)
+                    tname = translated_tournament_name(
+                        variant, MONTHLY, ARENA, translation
+                    )
                     self.tourneynames[lang][(variant, MONTHLY, ARENA)] = tname
                 if variant in SEATURDAY or variant in WEEKLY_VARIANTS:
-                    tname = translated_tournament_name(variant, WEEKLY, ARENA, translation)
+                    tname = translated_tournament_name(
+                        variant, WEEKLY, ARENA, translation
+                    )
                     self.tourneynames[lang][(variant, WEEKLY, ARENA)] = tname
                 if variant in SHIELDS:
-                    tname = translated_tournament_name(variant, SHIELD, ARENA, translation)
+                    tname = translated_tournament_name(
+                        variant, SHIELD, ARENA, translation
+                    )
                     self.tourneynames[lang][(variant, SHIELD, ARENA)] = tname
 
         # https://github.com/aio-libs/aiohttp-jinja2/issues/187#issuecomment-2519831516
@@ -856,7 +918,11 @@ class PychessGlobalAppState:
                 if removed is None:
                     # The queue may already be gone when cleanup runs after
                     # reconnect/disconnect races or repeated cache removals.
-                    log.debug("%s already missing from %s.game_queues", game.id, player.username)
+                    log.debug(
+                        "%s already missing from %s.game_queues",
+                        game.id,
+                        player.username,
+                    )
 
         for player in game.all_players:
             if player.game_in_progress == game.id:
@@ -883,7 +949,9 @@ class PychessGlobalAppState:
         self.game_remove_tasks.pop(game.id, None)
         await self._evict_game_from_cache(game)
 
-    async def maybe_remove_finished_game_from_cache_now(self, game: Game | GameBug) -> None:
+    async def maybe_remove_finished_game_from_cache_now(
+        self, game: Game | GameBug
+    ) -> None:
         if game.status <= STARTED or game.id not in self.games:
             return
 
@@ -892,10 +960,15 @@ class PychessGlobalAppState:
         if has_pending_analysis_work_for_game(self, game.id):
             return
 
-        if any(player.is_user_active_in_game(game.id) for player in game.non_bot_players):
+        if any(
+            player.is_user_active_in_game(game.id) for player in game.non_bot_players
+        ):
             return
 
-        if any(spectator.is_user_active_in_game(game.id) for spectator in tuple(game.spectators)):
+        if any(
+            spectator.is_user_active_in_game(game.id)
+            for spectator in tuple(game.spectators)
+        ):
             return
 
         await self.remove_game_from_cache_now(game)
@@ -915,7 +988,9 @@ class PychessGlobalAppState:
         return result
 
     async def remove_from_cache(self, game):
-        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME)
+        await asyncio.sleep(
+            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME
+        )
         await self._evict_game_from_cache(game)
 
     def schedule_tournament_cache_removal(self, tournament: Tournament):
@@ -938,7 +1013,9 @@ class PychessGlobalAppState:
         task.add_done_callback(_cleanup_task)
 
     async def remove_tournament_from_cache(self, tournament_id: str):
-        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME)
+        await asyncio.sleep(
+            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME
+        )
 
         tournament = self.tournaments.get(tournament_id)
         if tournament is None or tournament.status <= T_STARTED:
@@ -1112,7 +1189,9 @@ class PychessGlobalAppState:
         return sum((1 for user in self.users.values() if user.online))
 
     def auto_pairing_count(self):
-        return sum((1 for user in self.auto_pairing_users if user.ready_for_auto_pairing))
+        return sum(
+            (1 for user in self.auto_pairing_users if user.ready_for_auto_pairing)
+        )
 
     def __str__(self):
         return self.__stringify(str)

--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -106,17 +106,13 @@ from startup_timer import StartupTimer
 log = logging.getLogger(__name__)
 
 GAME_KEEP_TIME = 1800  # keep game in app[games_key] for GAME_KEEP_TIME secs
-TOURNAMENT_KEEP_TIME = (
-    1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
-)
+TOURNAMENT_KEEP_TIME = 1800  # keep ended tournaments in cache for TOURNAMENT_KEEP_TIME secs
 T = TypeVar("T")
 USERNAME_LOWER_FIELD = "username_lower"
 
 
 def _is_test_run() -> bool:
-    return any("pytest" in arg for arg in sys.argv) or any(
-        "unittest" in arg for arg in sys.argv
-    )
+    return any("pytest" in arg for arg in sys.argv) or any("unittest" in arg for arg in sys.argv)
 
 
 # Local test cache retention; keep this small for test runs, but use the
@@ -149,9 +145,7 @@ class PychessGlobalAppState:
             self.lobby = Lobby(self)
             self.chat_flood = ChatFlood()
             # one dict per tournament! {tournamentId: {user.username: user.tournament_sockets, ...}, ...}
-            self.tourneysockets: dict[
-                str, dict[str, set[WebSocketResponse | None]]
-            ] = {}
+            self.tourneysockets: dict[str, dict[str, set[WebSocketResponse | None]]] = {}
             self.background_tasks: set[asyncio.Task[Any]] = set()
             self.game_remove_tasks: dict[str, asyncio.Task[None]] = {}
             self.tournament_remove_tasks: dict[str, asyncio.Task[None]] = {}
@@ -179,9 +173,7 @@ class PychessGlobalAppState:
             # given gameId is ready. challenge_accept/decline wait on this instead
             # of busy-polling invite_channels.
             self.invite_events: dict[str, asyncio.Event] = {}
-            self.highscore = {
-                variant: ValueSortedDict(neg) for variant in RATED_VARIANTS
-            }
+            self.highscore = {variant: ValueSortedDict(neg) for variant in RATED_VARIANTS}
             self.lobby_leaderboard: list["LobbyLeaderboardEntry"] = []
             self.lobby_tournament_winners: list["TournamentWinnerEntry"] = []
             self.shield = {}
@@ -236,18 +228,14 @@ class PychessGlobalAppState:
             self.started_at = datetime.now(timezone.utc)
             self.push_notifier = PushNotifier(self)
             if self.push_notifier.enabled:
-                self.create_background_task(
-                    self.push_notifier.run(), name="push-notifier"
-                )
+                self.create_background_task(self.push_notifier.run(), name="push-notifier")
 
         startup.log_summary()
 
     async def init_from_db(self):
         startup = StartupTimer(log, "PychessGlobalAppState.init_from_db")
         if self.db is None:
-            log.debug(
-                "[startup] PychessGlobalAppState.init_from_db skipped: no database"
-            )
+            log.debug("[startup] PychessGlobalAppState.init_from_db skipped: no database")
             startup.log_summary()
             return
 
@@ -257,9 +245,7 @@ class PychessGlobalAppState:
                 if doc_id is None:
                     continue
                 update = {key: value for key, value in doc.items() if key != "_id"}
-                await collection.update_one(
-                    {"_id": doc_id}, {"$set": update}, upsert=True
-                )
+                await collection.update_one({"_id": doc_id}, {"$set": update}, upsert=True)
 
         # Read tournaments, users and highscore from db
         try:
@@ -267,9 +253,7 @@ class PychessGlobalAppState:
                 db_collections = await self.db.list_collection_names()
 
                 puzzle = await self.db.puzzle.find_one()
-                puzzle_doc_rename_needed = (puzzle is not None) and (
-                    "variant" in puzzle
-                )
+                puzzle_doc_rename_needed = (puzzle is not None) and ("variant" in puzzle)
                 if puzzle_doc_rename_needed:
                     await rename_puzzle_fields(self.db)
 
@@ -291,9 +275,7 @@ class PychessGlobalAppState:
                     {"$or": [{"status": T_STARTED}, {"status": T_CREATED}]}
                 )
                 cursor.sort("startsAt", -1)
-                to_date = (
-                    datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)
-                ).date()
+                to_date = (datetime.now(timezone.utc) + timedelta(days=SCHEDULE_MAX_DAYS)).date()
                 async for doc in cursor:
                     if doc["status"] == T_STARTED or (
                         doc["status"] == T_CREATED and doc["startsAt"].date() <= to_date
@@ -307,9 +289,7 @@ class PychessGlobalAppState:
                 await create_scheduled_tournaments(self, new_tournaments_data)
 
             with startup.phase("restore highscore + lobby caches"):
-                self.create_background_task(
-                    generate_shield(self), name="generate-shield"
-                )
+                self.create_background_task(generate_shield(self), name="generate-shield")
 
                 if "highscore" not in db_collections:
                     await generate_highscore(self)
@@ -338,9 +318,7 @@ class PychessGlobalAppState:
                 else:
                     cursor = self.db.dailypuzzle.find()
                     docs = await cursor.to_list(length=365 * len(GAME_CATEGORIES))
-                    self.daily_puzzle_ids = {
-                        doc["_id"]: doc["puzzleId"] for doc in docs
-                    }
+                    self.daily_puzzle_ids = {doc["_id"]: doc["puzzleId"] for doc in docs}
 
                 if "lobbychat" not in db_collections:
                     try:
@@ -370,15 +348,9 @@ class PychessGlobalAppState:
                 await self.db.game.create_index("by")
                 await self.db.game.create_index("c")
                 await self.db.game.create_index("tid")
-                await self.db.game.create_index(
-                    [("us", 1), ("d", -1)], name="us_d_desc"
-                )
-                await self.db.game.create_index(
-                    [("us.0", 1), ("d", -1)], name="us0_d_desc"
-                )
-                await self.db.game.create_index(
-                    [("us.1", 1), ("d", -1)], name="us1_d_desc"
-                )
+                await self.db.game.create_index([("us", 1), ("d", -1)], name="us_d_desc")
+                await self.db.game.create_index([("us.0", 1), ("d", -1)], name="us0_d_desc")
+                await self.db.game.create_index([("us.1", 1), ("d", -1)], name="us1_d_desc")
                 await self.db.game.create_index(
                     [("us.0", 1), ("us.1", 1), ("d", -1)],
                     name="us0_us1_d_desc",
@@ -425,12 +397,8 @@ class PychessGlobalAppState:
 
                 if "forum_post" not in db_collections:
                     await self.db.create_collection("forum_post")
-                await self.db.forum_post.create_index(
-                    [("topicId", 1), ("createdAt", 1)]
-                )
-                await self.db.forum_post.create_index(
-                    [("categId", 1), ("createdAt", -1)]
-                )
+                await self.db.forum_post.create_index([("topicId", 1), ("createdAt", 1)])
+                await self.db.forum_post.create_index([("categId", 1), ("createdAt", -1)])
                 await self.db.forum_post.create_index([("text", "text")])
 
                 if "user_report" not in db_collections:
@@ -446,9 +414,7 @@ class PychessGlobalAppState:
 
                 if "security_ban_signal" not in db_collections:
                     await self.db.create_collection("security_ban_signal")
-                await self.db.security_ban_signal.create_index(
-                    "expireAt", expireAfterSeconds=0
-                )
+                await self.db.security_ban_signal.create_index("expireAt", expireAfterSeconds=0)
 
             with startup.phase("restore autopairings + seeks"):
                 # Load auto pairings from database
@@ -490,10 +456,7 @@ class PychessGlobalAppState:
                             challenge_decline_reason=doc.get("challengeDeclineReason"),
                         )
                         if not should_restore_persisted_seek(seek):
-                            log.debug(
-                                "Skipping non-restorable seek from database: %s",
-                                seek.id,
-                            )
+                            log.debug("Skipping non-restorable seek from database: %s", seek.id)
                             continue
                         log.debug("Loading seek from database: %s" % seek)
                         self.seeks[seek.id] = seek
@@ -553,9 +516,7 @@ class PychessGlobalAppState:
                 async for doc in cursor:
                     if corr:
                         # Don't load old never-started correspondence games.
-                        if doc["s"] == -2 and doc["d"] < today - timedelta(
-                            days=doc.get("b", 1)
-                        ):
+                        if doc["s"] == -2 and doc["d"] < today - timedelta(days=doc.get("b", 1)):
                             skipped += 1
                             continue
                     else:
@@ -583,9 +544,7 @@ class PychessGlobalAppState:
                     }
                 )
                 live_cursor.sort("d", -1)
-                live_loaded, live_skipped = await restore_active_games(
-                    live_cursor, corr=False
-                )
+                live_loaded, live_skipped = await restore_active_games(live_cursor, corr=False)
                 log.info(
                     "Loaded active live games from db: %s loaded, %s skipped",
                     live_loaded,
@@ -596,9 +555,7 @@ class PychessGlobalAppState:
                 try:
                     corr_cursor = self.db.game.find({**active_game_filter, "c": True})
                     corr_cursor.sort("d", -1)
-                    corr_loaded, corr_skipped = await restore_active_games(
-                        corr_cursor, corr=True
-                    )
+                    corr_loaded, corr_skipped = await restore_active_games(corr_cursor, corr=True)
                     log.info(
                         "Loaded active correspondence games from db: %s loaded, %s skipped",
                         corr_loaded,
@@ -632,19 +589,12 @@ class PychessGlobalAppState:
                     # Run legacy bootstrap only for an empty target collection.
                     # This keeps first deploy fully automatic while preventing rewrites
                     # of migrated posts on every subsequent restart.
-                    ublog_post_count = await self.db.ublog_post.count_documents(
-                        {}, limit=1
-                    )
+                    ublog_post_count = await self.db.ublog_post.count_documents({}, limit=1)
                     if ublog_post_count == 0:
                         from legacy_blog_migration import build_legacy_ublog_docs
 
-                        legacy_blog_author_policy = os.getenv(
-                            "LEGACY_BLOG_AUTHOR_POLICY", "keep"
-                        )
-                        if legacy_blog_author_policy not in (
-                            "keep",
-                            "official-as-pychess",
-                        ):
+                        legacy_blog_author_policy = os.getenv("LEGACY_BLOG_AUTHOR_POLICY", "keep")
+                        if legacy_blog_author_policy not in ("keep", "official-as-pychess"):
                             legacy_blog_author_policy = "keep"
                         await upsert_static_docs(
                             self.db.ublog_post,
@@ -739,9 +689,7 @@ class PychessGlobalAppState:
 
             # Create translation class
             try:
-                translation = gettext.translation(
-                    "server", localedir="lang", languages=[lang]
-                )
+                translation = gettext.translation("server", localedir="lang", languages=[lang])
             except FileNotFoundError:
                 log.warning("Missing translations file for lang %s", lang)
                 translation = gettext.NullTranslations()
@@ -757,19 +705,13 @@ class PychessGlobalAppState:
                     or variant in SEATURDAY
                     or variant in PAUSED_MONTHLY_VARIANTS
                 ):
-                    tname = translated_tournament_name(
-                        variant, MONTHLY, ARENA, translation
-                    )
+                    tname = translated_tournament_name(variant, MONTHLY, ARENA, translation)
                     self.tourneynames[lang][(variant, MONTHLY, ARENA)] = tname
                 if variant in SEATURDAY or variant in WEEKLY_VARIANTS:
-                    tname = translated_tournament_name(
-                        variant, WEEKLY, ARENA, translation
-                    )
+                    tname = translated_tournament_name(variant, WEEKLY, ARENA, translation)
                     self.tourneynames[lang][(variant, WEEKLY, ARENA)] = tname
                 if variant in SHIELDS:
-                    tname = translated_tournament_name(
-                        variant, SHIELD, ARENA, translation
-                    )
+                    tname = translated_tournament_name(variant, SHIELD, ARENA, translation)
                     self.tourneynames[lang][(variant, SHIELD, ARENA)] = tname
 
         # https://github.com/aio-libs/aiohttp-jinja2/issues/187#issuecomment-2519831516
@@ -918,11 +860,7 @@ class PychessGlobalAppState:
                 if removed is None:
                     # The queue may already be gone when cleanup runs after
                     # reconnect/disconnect races or repeated cache removals.
-                    log.debug(
-                        "%s already missing from %s.game_queues",
-                        game.id,
-                        player.username,
-                    )
+                    log.debug("%s already missing from %s.game_queues", game.id, player.username)
 
         for player in game.all_players:
             if player.game_in_progress == game.id:
@@ -949,9 +887,7 @@ class PychessGlobalAppState:
         self.game_remove_tasks.pop(game.id, None)
         await self._evict_game_from_cache(game)
 
-    async def maybe_remove_finished_game_from_cache_now(
-        self, game: Game | GameBug
-    ) -> None:
+    async def maybe_remove_finished_game_from_cache_now(self, game: Game | GameBug) -> None:
         if game.status <= STARTED or game.id not in self.games:
             return
 
@@ -960,15 +896,10 @@ class PychessGlobalAppState:
         if has_pending_analysis_work_for_game(self, game.id):
             return
 
-        if any(
-            player.is_user_active_in_game(game.id) for player in game.non_bot_players
-        ):
+        if any(player.is_user_active_in_game(game.id) for player in game.non_bot_players):
             return
 
-        if any(
-            spectator.is_user_active_in_game(game.id)
-            for spectator in tuple(game.spectators)
-        ):
+        if any(spectator.is_user_active_in_game(game.id) for spectator in tuple(game.spectators)):
             return
 
         await self.remove_game_from_cache_now(game)
@@ -988,9 +919,7 @@ class PychessGlobalAppState:
         return result
 
     async def remove_from_cache(self, game):
-        await asyncio.sleep(
-            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME
-        )
+        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else GAME_KEEP_TIME)
         await self._evict_game_from_cache(game)
 
     def schedule_tournament_cache_removal(self, tournament: Tournament):
@@ -1013,9 +942,7 @@ class PychessGlobalAppState:
         task.add_done_callback(_cleanup_task)
 
     async def remove_tournament_from_cache(self, tournament_id: str):
-        await asyncio.sleep(
-            LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME
-        )
+        await asyncio.sleep(LOCALHOST_CACHE_KEEP_TIME if URI == LOCALHOST else TOURNAMENT_KEEP_TIME)
 
         tournament = self.tournaments.get(tournament_id)
         if tournament is None or tournament.status <= T_STARTED:
@@ -1189,9 +1116,7 @@ class PychessGlobalAppState:
         return sum((1 for user in self.users.values() if user.online))
 
     def auto_pairing_count(self):
-        return sum(
-            (1 for user in self.auto_pairing_users if user.ready_for_auto_pairing)
-        )
+        return sum((1 for user in self.auto_pairing_users if user.ready_for_auto_pairing))
 
     def __str__(self):
         return self.__stringify(str)

--- a/tests/test_games_api.py
+++ b/tests/test_games_api.py
@@ -591,7 +591,7 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
 
     async def test_subscribe_invites_handles_sse_setup_error(self):
         game_id = "abcd1234"
-        app_state = SimpleNamespace(invite_channels={game_id: set()})
+        app_state = SimpleNamespace(invite_channels={game_id: set()}, invite_events={})
         request = SimpleNamespace(app=object(), match_info={"gameId": game_id})
 
         with (


### PR DESCRIPTION
Two bugs in the bot challenge flow:

1. `challenge_accept()` called `asyncio.sleep(1)` without `await` — the
   coroutine was created and immediately discarded, so the loop never
   actually waited. The SSE channel check was effectively a tight spin
   for up to 10 iterations with zero delay.

2. `challenge_decline()` had `await asyncio.sleep(1)` correctly, but
   still busy-polled for up to 10 seconds, blocking the event loop on
   each iteration.

**Fix:** zero-polling `asyncio.Event` mechanism across three files:

- `pychess_global_app_state.py`: add `invite_events: dict[str, asyncio.Event]`
- `game_api.py` — `subscribe_invites()`: after the queue is registered in
  `invite_channels`, call `event.set()` if an event exists for that gameId
- `bot_api.py` — both handlers: if the channel isn't ready yet, create the
  event via `setdefault` and `await asyncio.wait_for(event.wait(), timeout=10.0)`;
  clean up in `finally`; use `.get()` instead of direct key access for safety

If `subscribe_invites()` arrives before `challenge_accept/decline` (the
common case), the channel is already present and the event block is skipped
entirely. If it arrives after, the event fires the instant the SSE channel
registers — no polling, no unnecessary delay.
