### PR TITLE
perf: use uvloop as asyncio event loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "sortedcollections==2.1.0",
     "tenacity==9.1.4",
     "tzdata==2026.2",
+    "uvloop==0.22.1",
     "msgspec==0.21.1",
 ]
 

--- a/server/server.py
+++ b/server/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logger
 import argparse
 import asyncio
+import uvloop
 import faulthandler
 import logging
 import os
@@ -267,6 +268,7 @@ if __name__ == "__main__":
     startup.log_summary()
     log.info("[startup] handing off to aiohttp web.run_app()")
 
+    uvloop.install()
     web.run_app(
         app,
         access_log=None,


### PR DESCRIPTION
Replace the default asyncio event loop with uvloop, a fast drop-in
replacement built on libuv (the same C library powering Node.js).

**Why uvloop?**
The default asyncio event loop is implemented in pure Python with a thin
C accelerator. uvloop reimplements the entire event loop in Cython on top
of libuv, which means all I/O polling, callback scheduling, and socket
operations go through battle-tested C code instead of Python objects.

**How it works**
One call before web.run_app():

    uvloop.install()  # replaces the default loop policy process-wide

No other code changes needed. uvloop is a complete asyncio-compatible
drop-in: all existing asyncio primitives (Event, Queue, wait_for, etc.)
work identically. The change is invisible to the rest of the codebase.

**Expected gains for pychess**
The workload here is almost entirely I/O-bound async: WebSocket fan-out,
SSE channels, MongoDB queries, lobby broadcasts. This is exactly where
uvloop shines. Benchmarks from the uvloop authors show 2–4× throughput
improvement over the stock loop on echo-server style workloads; real-world
async web servers typically see 20–50% improvement in requests/sec and
reduced latency under load.

The broadcast optimisation in #2199 reduced unnecessary serialisation work;
uvloop reduces the cost of every remaining I/O dispatch on top of that.

**Compatibility**
uvloop supports Python 3.8–3.14 and runs on Linux and macOS. Heroku's
Linux dynos are a supported target. Windows is the only unsupported
platform, which is not relevant here.
