### PR TITLE
opt: replace O(N²) lookups with O(N) dict in arena pairing

### DIFF
--- a/server/tournament/arena.py
+++ b/server/tournament/arena.py
@@ -97,8 +97,8 @@ class ArenaTournament(Tournament):
         # print(rx_nodes)
         # print("---")
 
-        sorted_usernames = [p.username for p in self.leaderboard]
-        ranks = [sorted_usernames.index(p.username) + 1 for p in waiting_players]
+        rank_by_username = {p.username: i + 1 for i, p in enumerate(self.leaderboard)}
+        ranks = [rank_by_username[p.username] for p in waiting_players]
         rank_max = max(ranks)
 
         # https://github.com/lichess-org/lila/blob/master/modules/tournament/src/main/arena/PairingSystem.scala
@@ -138,12 +138,11 @@ class ArenaTournament(Tournament):
 
         edges = list(rxg.edge_list())
         weights = rxg.edges()
+        edge_index: dict[tuple[int, int], int] = {pair: i for i, pair in enumerate(edges)}
         sum_weight = 0
         for pair in matching:
-            try:
-                ind = edges.index(pair)
-            except ValueError:
-                ind = edges.index((pair[1], pair[0]))
+            ind = edge_index[pair] if pair in edge_index else edge_index[(pair[1], pair[0])]
+            sum_weight += weights[ind]
             sum_weight += weights[ind]
             log.debug("%r %r %r", rxg[pair[0]], rxg[pair[1]], weights[ind])
 


### PR DESCRIPTION
Two linear scans inside loops in `create_pairing()`:

1. `sorted_usernames.index(p.username)`: called once per waiting player,
   making rank lookup `O(N×W)` where `N` = leaderboard size and `W` = waiting
   players. Replaced with `{username: rank}` dict built once in `O(N)`,
   reducing each lookup to `O(1)`.

2. `edges.index(pair)` inside the matching loop: same pattern with the
   `rustworkx` edge list. Replaced with `{pair: index}` dict built once
   from `enumerate(edges)`, also `O(1)` per lookup.

Both call sites have identical observable behaviour; only the complexity
changes.
