### PR TITLE
fix: clear game_sockets after close and return JSON on block quota exceeded

### DIFF
--- a/server/user.py
+++ b/server/user.py
@@ -616,14 +616,13 @@ class User:
         await ws_send_str_many(ws_set, payload)
 
     async def close_all_game_sockets(self) -> None:
-        for ws_set in tuple(
-            self.game_sockets.values()
-        ):  # todo: also clean up this dict after closing?
+        for ws_set in tuple(self.game_sockets.values()):
             for ws in tuple(ws_set):
                 try:
                     await ws.close()
                 except Exception:
                     log.error("close_all_game_sockets() Exception for %s %s", self.username, ws)
+        self.game_sockets.clear()
 
     def is_user_active_in_game(self, game_id: str | None = None) -> bool:
         # todo: maybe also check if ws is still open or that the sets corresponding to (each) game_id are not empty?
@@ -897,8 +896,7 @@ async def block_user(request: web.Request) -> web.StreamResponse:
         return web.Response(status=403)
 
     if len(user.blocked) >= MAX_USER_BLOCK:
-        # TODO: Alert the user about blocked quota reached
-        raise web.HTTPFound("/@/%s" % profileId)
+        return json_response({"error": "blocked_quota_reached"}, status=400)
 
     post_data = await read_post_data(request)
     if post_data is None:


### PR DESCRIPTION
Two small fixes in `server/user.py`:

### 1. `close_all_game_sockets()` — clear dict after closing

After closing all WebSocket connections, `self.game_sockets` was not cleared.
Closed `WebSocketResponse` objects remained referenced in the dict, preventing
garbage collection. `is_user_active_in_game()` reads `len(self.game_sockets)`,
so it also incorrectly returned `True` after all connections had been closed.

The existing `# todo: also clean up this dict after closing?` comment identified
this gap.

**Fix:** Add `self.game_sockets.clear()` after the close loop and remove the
resolved TODO.

### 2. `block_user()` — return JSON 400 when block quota is exceeded

When `len(user.blocked) >= MAX_USER_BLOCK`, the handler raised `web.HTTPFound`
(HTTP 302) to the user's profile page. The rest of the handler returns
`json_response({})`, so this is inconsistent. A JavaScript client making a
fetch/XHR request silently follows the redirect instead of receiving an error.

The existing `# TODO: Alert the user about blocked quota reached` comment
confirmed this was a known gap.

**Fix:** Replace the redirect with `json_response({"error":
"blocked_quota_reached"}, status=400)`.
