### PR TITLE
fix: log warning when Fairy-Stockfish falls back to Random-Mover

### DIFF
--- a/server/wsr.py
+++ b/server/wsr.py
@@ -696,6 +696,7 @@ async def handle_rematch(
             if not engine.online:
                 if engine.username in ("Fairy-Stockfish", "Random-Mover"):
                     # Preserve old built-in-AI fallback behavior.
+                    log.warning("%s is offline, falling back to Random-Mover", engine.username)
                     engine = app_state.users["Random-Mover"]
                 else:
                     error_response = {


### PR DESCRIPTION
When `Fairy-Stockfish` (or `Random-Mover`) is offline during a rematch
request, the handler silently falls back to `Random-Mover`. No log entry
was produced, leaving server operators with no visibility into when this
fallback occurs.

**Fix:** Add `log.warning(...)` before the fallback assignment.
The existing comment and fallback logic are unchanged.
