### PR TITLE
Improve display of analysis settings

### DIFF
--- a/client/analysis/analysisSettings.ts
+++ b/client/analysis/analysisSettings.ts
@@ -38,6 +38,12 @@ class AnalysisSettings {
 
         const settingsList: VNode[] = [];
 
+        settingsList.push(this.settings['multipv'].view());
+
+        settingsList.push(this.settings['threads'].view());
+
+        settingsList.push(this.settings['hash'].view());
+
         settingsList.push(this.settings['arrow'].view());
 
         settingsList.push(this.settings['inlineNotation'].view());
@@ -46,15 +52,9 @@ class AnalysisSettings {
 
         settingsList.push(this.settings['infiniteAnalysis'].view());
 
-        settingsList.push(this.settings['multipv'].view());
-
-        settingsList.push(this.settings['threads'].view());
-
-        settingsList.push(this.settings['hash'].view());
+        settingsList.push(this.getSettings(variantName as string).view());
 
         settingsList.push(this.settings['nnue'].view());
-
-        settingsList.push(this.getSettings(variantName as string).view());
 
         settingsList.push(this.settings['fsfDebug'].view());
 

--- a/client/view.ts
+++ b/client/view.ts
@@ -83,6 +83,7 @@ export function checkbox(settings: Settings<boolean>, name: string, text: string
 export function toggleSwitch(settings: Settings<boolean>, name: string, text: string, disabled: boolean): VNode[] {
     const id = name;
     return [
+        h('label', { attrs: { for: id } }, text),
         h('label.switch', [
             h(`input#${id}`, {
                 props: { name: name, type: 'checkbox' },
@@ -91,7 +92,6 @@ export function toggleSwitch(settings: Settings<boolean>, name: string, text: st
             }),
             h('span.sw-slider'),
         ]),
-        h('label', { attrs: { for: id } }, text),
     ];
 }
 

--- a/static/site.css
+++ b/static/site.css
@@ -1272,8 +1272,15 @@ span.notification.empty span.text {
   display: flex;
   align-items: center;
   flex-direction: row;
+  justify-content: space-between;
 }
-.labelled label {
+.arrow-toggle{
+  margin-top: 20px;
+}
+.infiniteAnalysis-toggle {
+  margin-bottom: 20px;
+}
+.analysis-settings label {
   padding-left: 0;
 }
 div.labelled input[type="range"] {


### PR DESCRIPTION
Before and after:
<img width="300" height="339" alt="" src="https://github.com/user-attachments/assets/b02d7514-54df-4b75-8e28-0be68f02996b" /> <img width="300" height="339" alt="" src="https://github.com/user-attachments/assets/bc404a23-4d28-43b3-946c-75ea9b05363c" />

Lichess has changed its analysis settings (such as delegating some preferences to a modal), but I think this is sufficient for now.