### PR TITLE
Keep -a test-user identities alive and give them readable names

### DIFF
--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -48,6 +48,7 @@ from const import (
     STARTED,
     T_CREATED,
     T_STARTED,
+    TEST_PREFIX,
     WEEKLY,
     reserved,
 )
@@ -836,6 +837,14 @@ class PychessGlobalAppState:
         # Keep GC telemetry isolated in its own module to reduce changes here.
         # The helper starts a task only when GC_STATS_INTERVAL is configured.
         self.gc_stats_task = start_gc_telemetry(lambda: self.shutdown)
+
+    def is_test_user(self, username: str) -> bool:
+        """Whether this name belongs to a guest of the -a (anon_as_test_users) dev mode.
+
+        False in production whatever the name, so a real account that happens to
+        carry the prefix is never treated as a guest.
+        """
+        return self.anon_as_test_users and username.startswith(TEST_PREFIX)
 
     def registered_user_cache_references(self) -> set[User]:
         """Return users owned by live server state outside the global user cache."""

--- a/server/user.py
+++ b/server/user.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import random
+import re
 from asyncio import Queue
-from collections.abc import Coroutine, Mapping
+from collections.abc import Container, Coroutine, Mapping
 from datetime import MINYEAR, UTC, datetime
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -11,6 +13,7 @@ import aiohttp_session
 from aiohttp import web
 from aiohttp.web_ws import WebSocketResponse
 from broadcast import round_broadcast
+from catalogued_rules import PIECE_OPTION_NAMES
 from const import (
     ANON_PREFIX,
     BLOCK,
@@ -63,6 +66,51 @@ import logging
 from pychess_global_app_state_utils import get_app_state
 
 log = logging.getLogger(__name__)
+
+# Matches the registered-username limit enforced in login.py, so a test name is
+# never longer than a name a real account could hold.
+TEST_USERNAME_MAX_LENGTH = 20
+
+# How many random pairs to try before falling back to a numeric suffix.
+TEST_USERNAME_ATTEMPTS = 10
+
+
+def _camel_case(value: str) -> str:
+    return "".join(word.capitalize() for word in re.split(r"[^A-Za-z0-9]+", value) if word)
+
+
+# Piece labels the server already ships, CamelCased so that multi-word and
+# hyphenated entries stay usable: "shogi pawn" -> "ShogiPawn". 38 entries
+# collapse to 37 distinct words, all alphanumeric and letter-initial.
+_TEST_NAME_WORDS = sorted({_camel_case(name) for name in PIECE_OPTION_NAMES.values()})
+
+
+def _test_name_pair() -> str:
+    """Two different piece words, trimmed to the length budget, e.g. KnightCannon."""
+    first, second = random.sample(_TEST_NAME_WORDS, 2)
+    return (first + second)[: TEST_USERNAME_MAX_LENGTH - len(TEST_PREFIX)]
+
+
+def _generate_test_username(taken: Container[str]) -> str:
+    """A readable, unused name for a -a mode guest, e.g. Test–KnightCannon."""
+    for _ in range(TEST_USERNAME_ATTEMPTS):
+        username = TEST_PREFIX + _test_name_pair()
+        if username not in taken:
+            return username
+
+    # Every attempt collided. Add a counter, trimming the pair so the counter
+    # fits the budget rather than overflowing it — dropping the counter instead
+    # would hand back a name that is already in use. Piece words hold no digits,
+    # so each counter yields a distinct name and this terminates.
+    pair = _test_name_pair()
+    counter = 2
+    while True:
+        suffix = str(counter)
+        trimmed = pair[: TEST_USERNAME_MAX_LENGTH - len(TEST_PREFIX) - len(suffix)]
+        username = TEST_PREFIX + trimmed + suffix
+        if username not in taken:
+            return username
+        counter += 1
 
 
 SILENCE = 15 * 60
@@ -144,8 +192,8 @@ class User:
         if username is None:
             self.anon = not self.app_state.anon_as_test_users
             self.username: str = (
-                TEST_PREFIX if self.app_state.anon_as_test_users else ANON_PREFIX
-            ) + id8()
+                ANON_PREFIX + id8() if self.anon else _generate_test_username(self.app_state.users)
+            )
         else:
             self.username = username
 

--- a/server/users.py
+++ b/server/users.py
@@ -6,7 +6,14 @@ from collections.abc import Collection, ItemsView, ValuesView
 from time import monotonic
 from typing import TYPE_CHECKING
 
-from const import ANON_PREFIX, BLOCK, FOLLOW, MAX_USER_BLOCK, NONE_USER, reserved
+from const import (
+    ANON_PREFIX,
+    BLOCK,
+    FOLLOW,
+    MAX_USER_BLOCK,
+    NONE_USER,
+    reserved,
+)
 from typing_defs import RelationDocument, UserDocument
 from user import User
 
@@ -38,9 +45,19 @@ class Users(UserDict[str, User]):
         self.cache_access: dict[str, float] = {}
         self.registered_cache_evictions = 0
 
+    def _in_registered_cache(self, user: User) -> bool:
+        """Whether this user is subject to the registered-user cache TTL.
+
+        Test users are excluded alongside anons: they exist only in memory, so
+        evicting one destroys an identity that no db lookup can restore.
+        """
+        if user.anon or user.bot or reserved(user.username):
+            return False
+        return not self.app_state.is_test_user(user.username)
+
     def __setitem__(self, username: str, user: User) -> None:
         super().__setitem__(username, user)
-        if not (user.anon or user.bot or reserved(user.username)):
+        if self._in_registered_cache(user):
             self.cache_access[username] = monotonic()
         else:
             self.cache_access.pop(username, None)
@@ -52,7 +69,7 @@ class Users(UserDict[str, User]):
     def __getitem__(self, username: str) -> User:
         if username in self.data:
             user = self.data[username]
-            if not (user.anon or user.bot or reserved(user.username)):
+            if self._in_registered_cache(user):
                 self.cache_access[username] = monotonic()
             return user
         else:
@@ -126,9 +143,8 @@ class Users(UserDict[str, User]):
 
             return user
 
-    @staticmethod
-    def is_registered_cache_only(user: User, protected_users: Collection[User]) -> bool:
-        if user.anon or user.bot or reserved(user.username) or user in protected_users:
+    def is_registered_cache_only(self, user: User, protected_users: Collection[User]) -> bool:
+        if not self._in_registered_cache(user) or user in protected_users:
             return False
 
         user.update_online()


### PR DESCRIPTION
Two quality-of-life fixes for local development with `-a` (`anon_as_test_users`), where a guest browser is given a `Test–` identity instead of an anonymous one.

**The identity died after 30 minutes idle.** A test user is built with `anon=False`, so `Users` treated it as a registered user: `__setitem__` recorded a `cache_access` entry and the cleanup sweep evicted it past `REGISTERED_USER_CACHE_TTL`. Unlike a registered user there is no `db.user` row to reload from, so the next lookup returned `NONE_USER` and the browser was issued a fresh identity mid-session — losing track of who is who across several windows, and re-showing the first-visit "Game category filter" modal over the board.

`Users` now excludes test users from that cache the same way it already excludes anons. The predicate the touch points shared is factored into `Users._in_registered_cache()`, which also closes a gap: `__getitem__` stamps `cache_access` too, so skipping it only in `__setitem__` would have made the entry evictable again on the first read. Eviction of real registered users is unchanged.

`Users.get()` is deliberately untouched. A test username is only asserted by the session cookie, the server cannot verify it, and a test user is `anon=False` — so reconstructing one would grant seek, rated-path and tournament capability to an unverified name. An unknown test name still resolves to `NONE_USER` and the browser gets a new identity.

**Generated names were unreadable.** `TEST_PREFIX + id8()` produces `Test–a6NDUQuc`: impossible to hold in your head or tell apart at a glance in a four-window grid. They are now two different CamelCased piece names from the `PIECE_OPTION_NAMES` map the server already ships — `Test–KnightCannon`, `Test–AmazonPawn`. No new word list or module. CamelCasing keeps multi-word entries usable (`shogi pawn` → `ShogiPawn`), and the concatenation is trimmed to the 20 characters `login.py` allows a registered username, giving 1250 distinct names. On collision the numeric suffix replaces trailing characters rather than overflowing the limit, so it can never be dropped and hand back a name already in use.

Nothing changes when `anon_as_test_users` is off: `is_test_user()` on `PychessGlobalAppState` folds the flag check in with the prefix check, so a real account whose name happens to start with `Test–` is never treated as a guest.

**Testing:** `ruff format`, `ruff check`, `pyright` clean; `unittest discover -s tests` 839 passing, unchanged from before. Also exercised live against a local server across four browser windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
