### PR TITLE
Italicize intro for user-catalogued variants

### DIFF
--- a/static/variants.css
+++ b/static/variants.css
@@ -28,7 +28,7 @@ div.guide .catalogued-variant-rules h1,
 div.guide .catalogued-variant-rules h2,
 div.guide .catalogued-variant-rules .catalogued-variant-description,
 div.guide .catalogued-variant-rules .catalogued-variant-references,
-div.guide .catalogued-variant-rules .catalogued-variant-intro,
+.catalogued-variant-intro,
 div.guide .catalogued-variant-rules .catalogued-variant-kicker {
     margin: 0;
     padding: 0;
@@ -95,8 +95,10 @@ div.guide .catalogued-variant-rules h1 {
 }
 
 .catalogued-variant-intro {
+    font-style: italic;
     max-width: 60ch;
     opacity: 0.9;
+    margin-top: 20px;
 }
 
 .catalogued-variant-meta {

--- a/static/variants.css
+++ b/static/variants.css
@@ -65,10 +65,6 @@ div.guide .catalogued-variant-rules h1 {
     text-align: left;
 }
 
-.catalogued-variant-rules h2 {
-    padding: 0;
-}
-
 .catalogued-variant-kicker {
     margin: 0 0 0.35rem;
     padding: 0;


### PR DESCRIPTION
With description:
<img width="363" height="178" alt="" src="https://github.com/user-attachments/assets/5ccbf2e0-8346-4373-9f9d-99633041f291" /> <img width="363" height="176" alt="" src="https://github.com/user-attachments/assets/e0cbc272-53c6-4c9f-bb8d-37144ef13888" />
Without description:
<img width="335" height="125" alt="" src="https://github.com/user-attachments/assets/ebbba3e0-49d9-4fd5-86ae-949b7c068b0b" /> <img width="328" height="123" alt="4" src="https://github.com/user-attachments/assets/d0294442-6de9-4b5b-b9c7-306dbc1925b3" />

