### PR TITLE
Remove indent from tournament faq headings

### DIFF
--- a/static/tournament.css
+++ b/static/tournament.css
@@ -972,6 +972,7 @@ div.tour-faq {
 .tour-faq h2 {
   margin: 1.5em 0 .5em 0;
   font-size: 30px;
+  padding-left: 0;
 }
 .tour-faq p {
   padding: 0;


### PR DESCRIPTION
<img width="435" height="260" alt="" src="https://github.com/user-attachments/assets/8743c057-3ea9-4327-9563-de4319045892" /> <img width="448" height="257" alt="" src="https://github.com/user-attachments/assets/fb8f4e50-6fe2-4c73-b4a0-aa85a5e27260" />

