### PR TITLE
fix: Prefetch Fairy-Stockfish before joining games

### DIFF
--- a/server/views/lobby.py
+++ b/server/views/lobby.py
@@ -18,6 +18,7 @@ from views import add_corr_games_context, get_user_context
 @aiohttp_jinja2.template("index.html")
 async def lobby(request: web.Request) -> ViewContext:
     user, context = await get_user_context(request)
+    context["prefetch_ffish"] = True
 
     app_state = get_app_state(request.app)
 
@@ -37,6 +38,8 @@ async def lobby(request: web.Request) -> ViewContext:
     variant = request.match_info.get("variant")
     if (variant is not None) and (variant not in ALL_VARIANTS):
         variant = "chess"
+    if variant is not None:
+        context["variant"] = variant
 
     fen = request.rel_url.query.get("fen")
     selected_variant = request.rel_url.query.get("variant")

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,14 @@
             type="application/wasm"
             crossorigin="anonymous"
         >
+        {% elif view == "lobby" %}
+        <link
+            rel="prefetch"
+            href={{ static("ffish.wasm") }}
+            as="fetch"
+            type="application/wasm"
+            crossorigin="anonymous"
+        >
         {% endif %}
         <link rel="icon" href={{ static("favicon/favicon.ico") }} type="image/x-icon" />
     </head>

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,10 +29,10 @@
             type="application/wasm"
             crossorigin="anonymous"
         >
-        {% elif view == "lobby" %}
+        {% elif prefetch_ffish|default(false) %}
         <link
             rel="prefetch"
-            href={{ static("ffish.wasm") }}
+            href={{ static("ffish-alice.wasm" if variant == "alice" else "ffish.wasm") }}
             as="fetch"
             type="application/wasm"
             crossorigin="anonymous"

--- a/tests/test_wasm_resource_hints.py
+++ b/tests/test_wasm_resource_hints.py
@@ -4,6 +4,7 @@ from html.parser import HTMLParser
 from aiohttp.test_utils import AioHTTPTestCase
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from mongomock_motor import AsyncMongoMockClient
+
 from server import make_app
 
 

--- a/tests/test_wasm_resource_hints.py
+++ b/tests/test_wasm_resource_hints.py
@@ -1,0 +1,82 @@
+import unittest
+from html.parser import HTMLParser
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+class LinkParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "link":
+            self.links.append(dict(attrs))
+
+
+class WasmResourceHintsTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        environment = Environment(
+            loader=FileSystemLoader("templates"),
+            autoescape=select_autoescape(["html"]),
+        )
+        environment.globals["static"] = lambda path: "/static-root/%s" % path
+        cls.template = environment.get_template("base.html")
+
+    def wasm_hints(self, view, variant="chess"):
+        rendered = self.template.render(
+            title="Test", view=view, variant=variant, view_css="test.css"
+        )
+        parser = LinkParser()
+        parser.feed(rendered)
+        return [link for link in parser.links if link.get("href", "").endswith(".wasm")]
+
+    def test_lobby_prefetches_standard_engine(self):
+        self.assertEqual(
+            self.wasm_hints("lobby"),
+            [
+                {
+                    "rel": "prefetch",
+                    "href": "/static-root/ffish.wasm",
+                    "as": "fetch",
+                    "type": "application/wasm",
+                    "crossorigin": "anonymous",
+                }
+            ],
+        )
+
+    def test_standard_engine_views_preload_without_prefetch(self):
+        for view in ("round", "analysis"):
+            with self.subTest(view=view):
+                self.assertEqual(
+                    self.wasm_hints(view),
+                    [
+                        {
+                            "rel": "preload",
+                            "href": "/static-root/ffish.wasm",
+                            "as": "fetch",
+                            "type": "application/wasm",
+                            "crossorigin": "anonymous",
+                        }
+                    ],
+                )
+
+    def test_alice_engine_views_preload_only_alice_engine(self):
+        for view in ("round", "analysis"):
+            with self.subTest(view=view):
+                self.assertEqual(
+                    self.wasm_hints(view, variant="alice"),
+                    [
+                        {
+                            "rel": "preload",
+                            "href": "/static-root/ffish-alice.wasm",
+                            "as": "fetch",
+                            "type": "application/wasm",
+                            "crossorigin": "anonymous",
+                        }
+                    ],
+                )
+
+    def test_unrelated_view_has_no_wasm_resource_hint(self):
+        self.assertEqual(self.wasm_hints("profile"), [])

--- a/tests/test_wasm_resource_hints.py
+++ b/tests/test_wasm_resource_hints.py
@@ -1,7 +1,10 @@
 import unittest
 from html.parser import HTMLParser
 
+from aiohttp.test_utils import AioHTTPTestCase
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from mongomock_motor import AsyncMongoMockClient
+from server import make_app
 
 
 class LinkParser(HTMLParser):
@@ -26,7 +29,11 @@ class WasmResourceHintsTestCase(unittest.TestCase):
 
     def wasm_hints(self, view, variant="chess"):
         rendered = self.template.render(
-            title="Test", view=view, variant=variant, view_css="test.css"
+            title="Test",
+            view=view,
+            variant=variant,
+            view_css="test.css",
+            prefetch_ffish=view == "lobby",
         )
         parser = LinkParser()
         parser.feed(rendered)
@@ -80,3 +87,28 @@ class WasmResourceHintsTestCase(unittest.TestCase):
 
     def test_unrelated_view_has_no_wasm_resource_hint(self):
         self.assertEqual(self.wasm_hints("profile"), [])
+
+
+class LobbyWasmResourceHintsRequestTestCase(AioHTTPTestCase):
+    async def get_application(self):
+        return make_app(db_client=AsyncMongoMockClient(tz_aware=True))
+
+    async def tearDownAsync(self):
+        await self.client.close()
+
+    async def test_lobby_routes_prefetch_expected_engine(self):
+        routes = (
+            ("/", "ffish.wasm"),
+            ("/seek/alice", "ffish-alice.wasm"),
+            ("/?variant=alice", "ffish-alice.wasm"),
+            ("/@/Fairy-Stockfish/challenge", "ffish.wasm"),
+        )
+        for path, engine in routes:
+            with self.subTest(path=path):
+                response = await self.client.get(path)
+                self.assertEqual(response.status, 200)
+                parser = LinkParser()
+                parser.feed(await response.text())
+                hints = [link for link in parser.links if link.get("rel") == "prefetch"]
+                self.assertEqual(len(hints), 1)
+                self.assertIn(engine, hints[0]["href"])


### PR DESCRIPTION
Extend the resource-hint branch in `templates/base.html` so engine-backed views retain their existing `preload` of the exact module they immediately need, while the lobby emits a low-priority `prefetch` for standard `ffish.wasm`. Issue #2111 reports roughly ten-second cold page loads and fifteen-to-thirty-second waits when joining a game, with the clearest network trace showing the approximately 920 KiB `ffish.wasm` asset as the dominant game-page dependency.

Render the base template for the lobby and verify it emits exactly one low-priority fetch hint for the static-root-resolved `ffish.wasm`, with `as="fetch"`, `type="application/wasm"`, and `crossorigin="anonymous"`; Render a standard round/analysis view and verify it emits exactly one `preload` for `ffish.wasm` and no redundant lobby `prefetch`.

Fixes #2111
