### PR TITLE
Make login dropdown opaque

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -4159,20 +4159,18 @@ div button.login-btn {
   position: absolute;
   top: 100%;
   right: 0;
-  background: var(--bg-color);
+  background: var(--bg-color0);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   min-width: 180px;
   z-index: 1000;
-  opacity: 0;
   visibility: hidden;
   transform: translateY(-10px);
   transition: all 0.2s ease;
 }
 
 .login-dropdown.open .login-dropdown-menu {
-  opacity: 1;
   visibility: visible;
   transform: translateY(0);
 }


### PR DESCRIPTION
Before and after:
<img width="184" height="181" alt="" src="https://github.com/user-attachments/assets/18de89b7-8687-4eeb-95e3-345a82644e5a" /> <img width="195" height="179" alt="" src="https://github.com/user-attachments/assets/1188ecb7-d112-4fd7-aeab-883a94893f9e" />

Maybe bg-color1 or bg-color2 is better, not sure.