### PR TITLE
Use icon for tournament player count

### DIFF
--- a/static/tournaments.css
+++ b/static/tournaments.css
@@ -107,6 +107,14 @@ td .icon {
 .slist td:last-child {
     text-align: right;
 }
+.slist .nb-players {
+    white-space: nowrap;
+}
+.slist .nb-players .icon {
+    margin-right: 0.35em;
+    opacity: 0.75;
+    font-size: 1em;
+}
 td a {
     display: block;
     color: var(--font-color);

--- a/templates/tournaments.html
+++ b/templates/tournaments.html
@@ -52,7 +52,9 @@
                     </span>
                 </td>
                 <td>
-                    <span>{% trans count=tourney.nb_players %}{{ count }} player{% pluralize %}{{ count }} players{% endtrans %}</span>
+                    <span class="nb-players" title="{% trans count=tourney.nb_players %}{{ count }} player{% pluralize %}{{ count }} players{% endtrans %}">
+                        <i class="icon icon-online" aria-hidden="true"></i>{{ tourney.nb_players }}
+                    </span>
                 </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
Fixes #2285 — show tournament player count as icon + number so it no longer wraps on mobile.