### PR TITLE
Fix bot challenge notification race

### DIFF
--- a/server/game_api.py
+++ b/server/game_api.py
@@ -26,12 +26,13 @@ from const import (
     VARIANTEND,
 )
 from convert import zero2grand
-from json_utils import json_response
+from json_utils import json_dumps, json_response
 from preferences import effective_game_category
 from pychess_global_app_state_utils import get_app_state
 from pymongo.errors import BulkWriteError, ExecutionTimeout
+from seek import BOT_CHALLENGE_DECLINED
 from settings import ADMINS
-from sse_utils import consume_sse_queue
+from sse_utils import consume_sse_queue, enqueue_sse_payload
 from tournament.tournaments import get_tournament_name, load_tournament
 from utils import pgn
 from variants import C2V, GRANDS, VARIANTS, get_server_variant
@@ -568,6 +569,28 @@ async def cancel_invite(request: web.Request) -> web.StreamResponse:
     return web.HTTPFound("/")
 
 
+def invite_resolution_snapshot(app_state: PychessGlobalAppState, game_id: str) -> str | None:
+    """Return invite state that may have changed before the browser subscribed."""
+    if game_id in app_state.games:
+        return json_dumps({"gameId": game_id, "accept": True})
+
+    seek = app_state.invites.get(game_id)
+    if (
+        seek is not None
+        and seek.is_bot_challenge
+        and seek.bot_challenge_status == BOT_CHALLENGE_DECLINED
+    ):
+        return json_dumps(
+            {
+                "gameId": game_id,
+                "accept": False,
+                "declineReason": seek.bot_challenge_decline_reason or "",
+            }
+        )
+
+    return None
+
+
 async def subscribe_invites(request: web.Request) -> web.StreamResponse:
     app_state = get_app_state(request.app)
     gameId = request.match_info.get("gameId")
@@ -578,6 +601,10 @@ async def subscribe_invites(request: web.Request) -> web.StreamResponse:
     if gameId not in app_state.invite_channels:
         app_state.invite_channels[gameId] = set()
     app_state.invite_channels[gameId].add(queue)
+
+    snapshot = invite_resolution_snapshot(app_state, gameId)
+    if snapshot is not None:
+        enqueue_sse_payload(queue, snapshot, replace_pending=True)
 
     # Signal challenge_accept/decline that the SSE channel is now ready.
     event = app_state.invite_events.get(gameId)

--- a/server/game_api.py
+++ b/server/game_api.py
@@ -606,11 +606,6 @@ async def subscribe_invites(request: web.Request) -> web.StreamResponse:
     if snapshot is not None:
         enqueue_sse_payload(queue, snapshot, replace_pending=True)
 
-    # Signal challenge_accept/decline that the SSE channel is now ready.
-    event = app_state.invite_events.get(gameId)
-    if event is not None:
-        event.set()
-
     response: web.StreamResponse = web.Response(status=200)
     try:
         async with sse_response(request) as response:

--- a/server/pychess_global_app_state.py
+++ b/server/pychess_global_app_state.py
@@ -233,10 +233,6 @@ class PychessGlobalAppState:
             self.invites: dict[str, Seek] = {}
             self.game_channels: set[asyncio.Queue[str]] = set()
             self.invite_channels: dict[str, set[asyncio.Queue[str]]] = {}
-            # Signalled by subscribe_invites() as soon as the SSE channel for a
-            # given gameId is ready. challenge_accept/decline wait on this instead
-            # of busy-polling invite_channels.
-            self.invite_events: dict[str, asyncio.Event] = {}
             self.highscore = {variant: ValueSortedDict(neg) for variant in RATED_VARIANTS}
             self.lobby_leaderboard: list[LobbyLeaderboardEntry] = []
             self.lobby_tournament_winners: list[TournamentWinnerEntry] = []

--- a/tests/test_games_api.py
+++ b/tests/test_games_api.py
@@ -795,7 +795,6 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
             games={},
             invites={},
             invite_channels={game_id: invite_channels},
-            invite_events={},
         )
         request = SimpleNamespace(app=object(), match_info={"gameId": game_id})
 
@@ -817,7 +816,6 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
             games={game_id: object()},
             invites={},
             invite_channels={},
-            invite_events={},
         )
         request = SimpleNamespace(app=object(), match_info={"gameId": game_id})
         response = self._CapturingResponse()
@@ -849,7 +847,6 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
             games={},
             invites={game_id: seek},
             invite_channels={},
-            invite_events={},
         )
         request = SimpleNamespace(app=object(), match_info={"gameId": game_id})
         response = self._CapturingResponse()

--- a/tests/test_games_api.py
+++ b/tests/test_games_api.py
@@ -29,6 +29,7 @@ from glicko2.glicko2 import new_default_perf
 from mongomock_motor import AsyncMongoMockClient
 from pychess_global_app_state_utils import get_app_state
 from pymongo.errors import BulkWriteError
+from seek import BOT_CHALLENGE_DECLINED
 from settings import MONGO_DB_NAME
 from user import User
 from variants import VARIANTS, get_server_variant
@@ -748,6 +749,23 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
         async def get(self, _username):
             return self.user
 
+    class _CapturingResponse:
+        def __init__(self):
+            self.connected = True
+            self.payloads = []
+
+        def is_connected(self):
+            return self.connected
+
+        async def send(self, payload):
+            self.payloads.append(payload)
+            self.connected = False
+
+    @staticmethod
+    @asynccontextmanager
+    async def _capturing_sse_response(response, _request):
+        yield response
+
     async def test_subscribe_notify_handles_sse_setup_error(self):
         notify_channels = self._TrackingSet()
         notify_user = SimpleNamespace(notify_channels=notify_channels)
@@ -774,6 +792,8 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
         game_id = "abcd1234"
         invite_channels = self._TrackingSet()
         app_state = SimpleNamespace(
+            games={},
+            invites={},
             invite_channels={game_id: invite_channels},
             invite_events={},
         )
@@ -790,6 +810,64 @@ class SSESubscribeErrorFallbackTestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(invite_channels.added.maxsize, game_api.SSE_SNAPSHOT_QUEUE_MAXSIZE)
         with self.assertRaises(asyncio.QueueShutDown):
             invite_channels.added.get_nowait()
+
+    async def test_subscribe_invites_replays_accepted_game(self):
+        game_id = "abcd1234"
+        app_state = SimpleNamespace(
+            games={game_id: object()},
+            invites={},
+            invite_channels={},
+            invite_events={},
+        )
+        request = SimpleNamespace(app=object(), match_info={"gameId": game_id})
+        response = self._CapturingResponse()
+
+        with (
+            patch("game_api.get_app_state", return_value=app_state),
+            patch(
+                "game_api.sse_response",
+                lambda request: self._capturing_sse_response(response, request),
+            ),
+        ):
+            result = await game_api.subscribe_invites(request)
+
+        self.assertIs(result, response)
+        self.assertEqual(
+            [{"gameId": game_id, "accept": True}],
+            [json.loads(payload) for payload in response.payloads],
+        )
+
+    async def test_subscribe_invites_replays_bot_decline(self):
+        game_id = "abcd1234"
+        decline_reason = "I'm not willing to play this variant right now."
+        seek = SimpleNamespace(
+            is_bot_challenge=True,
+            bot_challenge_status=BOT_CHALLENGE_DECLINED,
+            bot_challenge_decline_reason=decline_reason,
+        )
+        app_state = SimpleNamespace(
+            games={},
+            invites={game_id: seek},
+            invite_channels={},
+            invite_events={},
+        )
+        request = SimpleNamespace(app=object(), match_info={"gameId": game_id})
+        response = self._CapturingResponse()
+
+        with (
+            patch("game_api.get_app_state", return_value=app_state),
+            patch(
+                "game_api.sse_response",
+                lambda request: self._capturing_sse_response(response, request),
+            ),
+        ):
+            result = await game_api.subscribe_invites(request)
+
+        self.assertIs(result, response)
+        self.assertEqual(
+            [{"gameId": game_id, "accept": False, "declineReason": decline_reason}],
+            [json.loads(payload) for payload in response.payloads],
+        )
 
     async def test_subscribe_inbox_handles_sse_setup_error(self):
         inbox_channels = self._TrackingSet()


### PR DESCRIPTION
The goal of this PR to remedy two issues which occurred when I challenged Alice-Stockfish BOT which was run by https://github.com/gbtami/pychess-bot. When I challenged it to a not supported variant the decline response not appeared. When I challenged it to play Alice chess game the game was created but I was not redirected to the already created game page.