### PR TITLE
docs(faq): use similarities instead of similitudes

### DIFF
--- a/static/docs/faq.md
+++ b/static/docs/faq.md
@@ -12,7 +12,7 @@ The server code is written in Python.</details>
 
 <details><summary>What is the difference between this and the software?</summary>
 
-Both are designed to play chess variants, and both share the same developer ([gbtami](https://www.github.com/gbtami)). However, the similitudes end there. The full name for this site is "Pychess Variants" for distinction, but is often just called Pychess. The site for the desktop application is [here](https://pychess.github.io/).</details>
+Both are designed to play chess variants, and both share the same developer ([gbtami](https://www.github.com/gbtami)). However, the similarities end there. The full name for this site is "Pychess Variants" for distinction, but is often just called Pychess. The site for the desktop application is [here](https://pychess.github.io/).</details>
 
 <details><summary>What is the relationship to [Lichess](https://lichess.org/)?</summary>
 


### PR DESCRIPTION
The English FAQ used similitudes, a false friend from French.
Prefer similarities.
