### PR TITLE
fix(engine): ignore postMessage Memory clone failure on iPadOS

### DIFF
--- a/client/fairyStockfish.ts
+++ b/client/fairyStockfish.ts
@@ -40,10 +40,16 @@ function wasmThreadsSupported(): boolean {
     if (!(memory.buffer instanceof SharedArrayBuffer)) return false;
 
     try {
-        window.postMessage(memory, '*');
         memory.grow(8);
     } catch {
         return false;
+    }
+
+    try {
+        window.postMessage(memory, '*');
+    } catch {
+        // iPadOS can reject cloning shared WebAssembly.Memory via postMessage
+        // even when Fairy-Stockfish workers run correctly.
     }
 
     return true;


### PR DESCRIPTION
Shared WebAssembly.Memory creation and grow succeed on iPadOS, but postMessage(memory) throws DataCloneError and blocked Fairy-Stockfish analysis.
Treat that clone failure as non-fatal after shared memory works.

Fixes #2335
