### PR TITLE
docs(alice): fix transfered spelling

### DIFF
--- a/static/docs/alice.md
+++ b/static/docs/alice.md
@@ -9,7 +9,7 @@ Alice chess is a chess variant invented in 1953 by V. R. Parton which employs tw
 
 - A move must be legal on the board where it is played.
 - A piece can only move or capture if the corresponding destination square on the other board is vacant.
-- After moving, the piece is transfered to the corresponding square on the other board.
+- After moving, the piece is transferred to the corresponding square on the other board.
 
 ## Clarification
 


### PR DESCRIPTION
Correct transfered to transferred in the Alice Chess guide.